### PR TITLE
feat: add SharePoint and OneDrive usage telemetry to license overview dashboard

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified Microsoft Graph API service layer."""

--- a/core/graph/client.py
+++ b/core/graph/client.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified client managing connection pools, authentication, and sessions for Microsoft Graph."""
+
+import logging
+from typing import List, Dict, Any, Union, Optional
+import requests
+from util.auth_manager import TokenManager
+from util.connectors import UrlInvoker
+
+logger = logging.getLogger(__name__)
+
+class GraphClient:
+    """Unified client managing credentials validation and connection slots to Microsoft Graph."""
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_ids: Union[str, List[str]],
+        client_secrets: Union[str, List[str]],
+        concurrency: int = 1,
+        retries: int = 5,
+        backoff: int = 2
+    ) -> None:
+        self.tenant_id = tenant_id
+        
+        # Normalize inputs to lists to perfectly match TokenManager parameters
+        self.client_ids = [client_ids] if isinstance(client_ids, str) else client_ids
+        self.client_secrets = [client_secrets] if isinstance(client_secrets, str) else client_secrets
+        
+        self.token_manager = TokenManager(
+            tenant_id=self.tenant_id,
+            client_ids=self.client_ids,
+            client_secrets=self.client_secrets,
+            concurrency=concurrency,
+            retries=retries,
+            backoff=backoff
+        )
+
+        self.url_invoker = UrlInvoker(
+            token_manager=self.token_manager,
+            batch_retry_count=retries,
+            batch_backoff=backoff,
+            initial_delay=1,
+            jitter=0.5
+        )
+
+    def authenticate(self, required_scopes: Optional[List[str]] = None) -> None:
+        """Validates Entra ID scopes and fetches active tokens."""
+        self.token_manager.authenticate_all(required_scopes=required_scopes)
+
+    def get_session(self) -> requests.Session:
+        """Returns the unified requests Session pool."""
+        return self.token_manager.get_session()
+
+    def get_active_token(self) -> Dict[str, Any]:
+        """Acquires an active, refreshed token slot from TokenManager lease queue."""
+        return self.token_manager.get_valid_token_slot()
+
+    def release_token(self, token_slot: Dict[str, Any]) -> None:
+        """Returns token slot to the queue, completing the lease cycle."""
+        self.token_manager.return_token_slot(token_slot)
+
+    def close(self) -> None:
+        """Releases all connection pool and socket resources."""
+        self.token_manager.close()
+
+    def __enter__(self) -> "GraphClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/core/graph/directory.py
+++ b/core/graph/directory.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DirectoryService for querying tenant details and subscribed SKUs config."""
+
+import logging
+from typing import Dict, Any
+from core.graph.client import GraphClient
+
+logger = logging.getLogger(__name__)
+
+class DirectoryService:
+    """Service to query Entra ID directory configuration details."""
+
+    def __init__(self, client: GraphClient) -> None:
+        self.client = client
+
+    def get_subscribed_skus(self) -> Dict[str, Any]:
+        """Queries the Microsoft Graph /subscribedSkus endpoint with active retries."""
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}",
+            "ConsistencyLevel": "eventual"
+        }
+        try:
+            url = "https://graph.microsoft.com/v1.0/subscribedSkus"
+            logger.info("Querying Graph API configuration endpoint: %s", url)
+            resp = session.get(url, headers=headers, timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()
+        finally:
+            self.client.release_token(token_slot)

--- a/core/graph/reports.py
+++ b/core/graph/reports.py
@@ -73,7 +73,7 @@ class ReportsService:
                             time.sleep(retry_interval)
                         else:
                             logger.error("Failed downloading %s after %d attempts.", output_filename, max_retries, exc_info=True)
-                            raise ConnectionError(f"Failed downloading report after {max_retries} attempts. Details: {error}")
+                            raise ConnectionError(f"Failed downloading report after %d attempts. Details: {error}")
                 
                 logger.info("Success! Saved report to: %s", output_path)
 
@@ -104,3 +104,29 @@ class ReportsService:
             # Gather all futures, raising exceptions if any thread failed
             for future in concurrent.futures.as_completed(futures):
                 future.result()
+
+    def download_o365_active_user_detail(self, output_dir: str) -> None:
+        """Downloads the Office 365 active user details CSV report (180 days)."""
+        url = "https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserDetail(period='D180')"
+        self.download_report(url, "Office365ActiveUserDetail(180d).csv", output_dir)
+
+    def download_o365_active_user_counts(self, output_dir: str) -> None:
+        """Downloads the Office 365 30-day active user counts CSV report."""
+        url = "https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D30')"
+        self.download_report(url, "Office365ActiveUserCounts(30d).csv", output_dir)
+
+    def download_m365_app_details(self, output_dir: str) -> None:
+        """Downloads both M365 App user details and counts CSV reports concurrently."""
+        reports = [
+            ("https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(period='D180')", "M365AppUserDetail(180d).csv"),
+            ("https://graph.microsoft.com/v1.0/reports/getM365AppUserCounts(period='D180')", "getM365AppUserCounts(180d).csv")
+        ]
+        self.download_reports_batch(reports, output_dir)
+
+    def download_sharepoint_onedrive_details(self, output_dir: str) -> None:
+        """Downloads SharePoint site usage and OneDrive account usage details CSV reports concurrently."""
+        reports = [
+            ("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv"),
+            ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv")
+        ]
+        self.download_reports_batch(reports, output_dir)

--- a/core/graph/reports.py
+++ b/core/graph/reports.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ReportsService encapsulating Microsoft Graph usage report generation and downloads."""
+
+import os
+import time
+import logging
+import concurrent.futures
+from typing import List, Tuple
+import requests
+from core.graph.client import GraphClient
+
+logger = logging.getLogger(__name__)
+
+class ReportsService:
+    """Service to fetch streaming M365 telemetry reports via Microsoft Graph API."""
+
+    def __init__(self, client: GraphClient) -> None:
+        self.client = client
+
+    def download_report(self, api_url: str, output_filename: str, output_dir: str) -> None:
+        """Downloads a single CSV report via a streaming connection utilizing GraphClient session."""
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+        
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}"
+        }
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, output_filename)
+
+        try:
+            logger.info("Calling Graph report endpoint for %s...", output_filename)
+            resp = session.get(api_url, headers=headers, allow_redirects=False, stream=True)
+            
+            # Graph APIs return status code 302 redirect to a pre-authenticated S3/Azure Blob URL
+            if resp.status_code == 302:
+                resp.close()
+                location_url = resp.headers.get("Location")
+                if not location_url:
+                    raise ConnectionError(f"302 redirect returned for {output_filename} but Location header is missing.")
+                
+                logger.info("Pre-authenticated storage redirect retrieved. Waiting 2 seconds before download...")
+                time.sleep(2)
+
+                max_retries = 5
+                retry_interval = 30
+                for attempt in range(1, max_retries + 1):
+                    try:
+                        logger.info("[Attempt %d/%d] Downloading report stream to %s...", attempt, max_retries, output_filename)
+                        with requests.get(location_url, stream=True) as csv_response:
+                            csv_response.raise_for_status()
+                            with open(output_path, "wb") as f:
+                                for chunk in csv_response.iter_content(chunk_size=8192):
+                                    if chunk:
+                                        f.write(chunk)
+                        break
+                    except requests.exceptions.RequestException as error:
+                        if attempt < max_retries:
+                            logger.warning("[Attempt %d/%d] Failed stream download. Retrying in %ds... (Error: %s)", attempt, max_retries, retry_interval, error)
+                            time.sleep(retry_interval)
+                        else:
+                            logger.error("Failed downloading %s after %d attempts.", output_filename, max_retries, exc_info=True)
+                            raise ConnectionError(f"Failed downloading report after {max_retries} attempts. Details: {error}")
+                
+                logger.info("Success! Saved report to: %s", output_path)
+
+            elif resp.status_code == 200:
+                logger.info("Unexpected 200 OK status returned. Saving direct streaming stream...")
+                with open(output_path, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                resp.close()
+                logger.info("Success! Saved report to: %s", output_path)
+            else:
+                resp.close()
+                logger.error("Graph report request failed with status code %d: %s", resp.status_code, resp.text)
+                raise ConnectionError(f"Microsoft Graph API request failed with status code {resp.status_code}")
+        finally:
+            self.client.release_token(token_slot)
+
+    def download_reports_batch(self, reports: List[Tuple[str, str]], output_dir: str) -> None:
+        """Downloads a list of reports concurrently using thread executors."""
+        logger.info("Starting parallel batch download for %d reports...", len(reports))
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(reports)) as executor:
+            futures = [
+                executor.submit(self.download_report, url, filename, output_dir)
+                for url, filename in reports
+            ]
+            # Gather all futures, raising exceptions if any thread failed
+            for future in concurrent.futures.as_completed(futures):
+                future.result()

--- a/estimators/factory.py
+++ b/estimators/factory.py
@@ -1,22 +1,27 @@
+from core.graph.client import GraphClient
 from estimators.chat_estimator import ChatEstimator
 from estimators.eo_group_mailbox_estimator import EOGroupMailBoxEstimator
 from estimators.eo_in_place_archive_estimator import EOInPlaceArchiveEstimator
 from estimators.eo_shared_mailbox_estimator import EOSharedMailBoxEstimator
+from estimators.file_estimator import FileEstimator
+from tests.files.mocks import MockUrlInvoker
 from util.auth_manager import TokenManager
 from util.connectors import UrlInvoker
 from util.utils import ScanConfig
-
+import json
+import os
 
 class EstimatorFactory:
-
   def __init__(
-      self,
-      manager: TokenManager,
-      config: ScanConfig,
-      logger,
-      stop_event,
-      id_to_display_name,
+    self,
+    config: ScanConfig,
+    client: GraphClient = None,
+    manager: TokenManager = None,
+    logger = None,
+    stop_event = None,
+    id_to_display_name = None
   ):
+    self.client = client
     self.manager = manager
     self.config = config
     self.logger = logger
@@ -25,8 +30,32 @@ class EstimatorFactory:
     self.shared_mail_box_estimator = None
     self.group_mail_box_estimator = None
     self.in_place_archive_estimator = None
+    self.files_estimator = None
     self.url_invoker = None
     self.chat_estimator = None
+    self.mock_url_invoker = None
+  
+  def isEmpty(self, data):
+    return data is None or len(data) == 0
+
+  def get_manager(self):
+    if not self.manager:
+      if self.client:
+        self.manager = self.client.token_manager
+      else:
+        if self.isEmpty(self.config.client_ids) or self.isEmpty(self.config.client_secrets) or self.isEmpty(self.config.tenant_id):
+          raise Exception("Missing credentials for tenant scan!!")
+        self.client = GraphClient(
+            self.config.tenant_id,
+            self.config.client_ids,
+            self.config.client_secrets,
+            self.config.concurrency,
+            self.config.retries,
+            self.config.backoff
+        )
+        self.manager = self.client.token_manager
+    
+    return self.manager
 
   def set_id_to_display_name(self, id_to_display_name):
     self.id_to_display_name = (
@@ -35,11 +64,31 @@ class EstimatorFactory:
 
   def get_url_invoker(self, hard_reset=False):
     if self.url_invoker is None or hard_reset:
-      self.url_invoker = UrlInvoker(
-          self.manager, self.config.retries, self.config.backoff, 1, 0.5
-      )
+      if self.client:
+        self.url_invoker = self.client.url_invoker
+      else:
+        manager = self.get_manager()
+        self.url_invoker = UrlInvoker(
+            manager, self.config.retries, self.config.backoff, 1, 0.5
+        )
 
     return self.url_invoker
+
+  def get_mock_url_invoker(self, hard_reset=False, seed=None):
+    if self.mock_url_invoker is None or hard_reset:
+      data_path = "tests/files/test_data/state.json"
+      if seed is not None:
+        data_path = f"tests/files/test_data/state_{seed}.json"
+
+      if not os.path.exists(data_path):
+        raise FileNotFoundError(f"Test data not found at {data_path}. Please run data_state_creator.py first.")
+          
+      with open(data_path, "r") as f:
+        test_data = json.load(f)
+
+      self.mock_url_invoker = MockUrlInvoker(test_data)
+
+    return self.mock_url_invoker
 
   def get_group_mailbox_estimator(self, hard_reset=False):
     if self.group_mail_box_estimator is None or hard_reset:
@@ -110,3 +159,22 @@ class EstimatorFactory:
       self.chat_estimator.set_id_to_display_name_map(self.id_to_display_name)
     return self.chat_estimator
 
+  def get_files_estimator(self, progress_update_callback=lambda x: None, hard_reset=False, use_mocks=False, mock_seed=None):
+    if self.files_estimator is None or hard_reset:
+      if self.files_estimator is not None:
+        self.files_estimator.shutdown()
+      
+      if not use_mocks:
+        url_invoker = self.get_url_invoker()
+      else:
+        url_invoker = self.get_mock_url_invoker(hard_reset=hard_reset, seed=mock_seed)
+      self.files_estimator = FileEstimator(
+        self.config,
+        url_invoker,
+        logger=self.logger,
+        stop_event=self.stop_event,
+        progress_update_callback=progress_update_callback
+      )
+      self.files_estimator.set_id_to_display_name_map(self.id_to_display_name)
+    
+    return self.files_estimator 

--- a/telemetry/active_users_usage.py
+++ b/telemetry/active_users_usage.py
@@ -26,23 +26,17 @@ from core.graph.reports import ReportsService
 # Bind to the async logger initialized in license_usage.py
 usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
 
-def _download_reports_via_service(client_id, client_secret, tenant_id, reports) -> None:
-    """Helper to instantiate GraphClient/ReportsService and perform concurrent downloads."""
+def _get_reports_service(client_id, client_secret, tenant_id) -> tuple[GraphClient, ReportsService]:
+    """Helper to instantiate GraphClient/ReportsService and manage credentials slots."""
     client = GraphClient(
         tenant_id=tenant_id,
         client_ids=client_id,
         client_secrets=client_secret,
-        concurrency=len(reports),
+        concurrency=2,
         retries=5,
         backoff=2
     )
-    service = ReportsService(client)
-    
-    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
-    reports_dir = os.path.join(script_dir, "reports")
-    
-    service.download_reports_batch(reports, reports_dir)
-    client.close()
+    return client, ReportsService(client)
 
 def process_active_user_detail(filepath):
     """Streams the downloaded CSV and calculates usage counters over 30, 90, and 180 days."""
@@ -188,26 +182,28 @@ def process_m365_app_user_detail(filepath):
 def run_o365_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for O365 Active User Data (Isolated for independent retries)."""
     usage_logger.info("Starting isolated O365 Pipeline...")
-    reports = [
-        ("https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserDetail(period='D180')", "Office365ActiveUserDetail(180d).csv")
-    ]
-    _download_reports_via_service(client_id, client_secret, tenant_id, reports)
+    client, service = _get_reports_service(client_id, client_secret, tenant_id)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
+    
+    service.download_o365_active_user_detail(reports_dir)
+    client.close()
+    
     return process_active_user_detail(os.path.join(reports_dir, "Office365ActiveUserDetail(180d).csv"))
 
 def run_o365_trend_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for O365 Trend Data (Isolated for independent retries)."""
     try:
         usage_logger.info("Starting isolated O365 Trend Pipeline...")
-        reports = [
-            ("https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D30')", "Office365ActiveUserCounts(30d).csv")
-        ]
-        _download_reports_via_service(client_id, client_secret, tenant_id, reports)
+        client, service = _get_reports_service(client_id, client_secret, tenant_id)
         
         script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
         reports_dir = os.path.join(script_dir, "reports")
+        
+        service.download_o365_active_user_counts(reports_dir)
+        client.close()
+        
         return process_active_user_counts(os.path.join(reports_dir, "Office365ActiveUserCounts(30d).csv"))
     except Exception as e:
         usage_logger.error("O365 Trend pipeline failed.", exc_info=True)
@@ -216,12 +212,12 @@ def run_o365_trend_pipeline(client_id, client_secret, tenant_id):
 def run_m365_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for M365 Apps Data (Isolated for independent retries)."""
     usage_logger.info("Starting isolated M365 Apps Pipeline...")
-    reports = [
-        ("https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(period='D180')", "M365AppUserDetail(180d).csv"),
-        ("https://graph.microsoft.com/v1.0/reports/getM365AppUserCounts(period='D180')", "getM365AppUserCounts(180d).csv")
-    ]
-    _download_reports_via_service(client_id, client_secret, tenant_id, reports)
+    client, service = _get_reports_service(client_id, client_secret, tenant_id)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
+    
+    service.download_m365_app_details(reports_dir)
+    client.close()
+    
     return process_m365_app_user_detail(os.path.join(reports_dir, "M365AppUserDetail(180d).csv"))

--- a/telemetry/active_users_usage.py
+++ b/telemetry/active_users_usage.py
@@ -1,106 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregations and data pipelines for O365 active user counts and details."""
+
 import os
-import requests
-import concurrent.futures
-import time
 import csv
 import logging
 from datetime import datetime, date
 
+# Import unified core service layer
+from core.graph.client import GraphClient
+from core.graph.reports import ReportsService
+
 # Bind to the async logger initialized in license_usage.py
 usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
 
-def get_access_token(client_id, client_secret, tenant_id):
-    """Fetches the OAuth 2.0 Access Token from Microsoft Entra ID."""
-    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-    token_data = {
-        "grant_type": "client_credentials",
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "scope": "https://graph.microsoft.com/.default"
-    }
-    
-    usage_logger.info("Fetching OAuth token from Microsoft Entra ID for usage reports...")
-    token_response = requests.post(token_url, data=token_data)
-    token_response.raise_for_status()
-    usage_logger.info("Successfully fetched OAuth token for usage reports.")
-    return token_response.json().get("access_token")
-
-def download_report(api_url, access_token, output_filename):
-    """Calls the Graph API and downloads the CSV report to the 'reports' folder using a streaming download."""
-    headers = {
-        "Authorization": f"Bearer {access_token}"
-    }
-    
-    usage_logger.info(f"Calling API for {output_filename} (intercepting redirect)...")
-    report_response = requests.get(api_url, headers=headers, allow_redirects=False, stream=True)
+def _download_reports_via_service(client_id, client_secret, tenant_id, reports) -> None:
+    """Helper to instantiate GraphClient/ReportsService and perform concurrent downloads."""
+    client = GraphClient(
+        tenant_id=tenant_id,
+        client_ids=client_id,
+        client_secrets=client_secret,
+        concurrency=len(reports),
+        retries=5,
+        backoff=2
+    )
+    service = ReportsService(client)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
-    os.makedirs(reports_dir, exist_ok=True)
     
-    output_path = os.path.join(reports_dir, output_filename)
-    
-    if report_response.status_code == 302:
-        report_response.close()
-        location_url = report_response.headers.get("Location")
-        if not location_url:
-            usage_logger.error(f"Received a 302 status for {output_filename} but no Location header was found.")
-            raise Exception(f"Received a 302 status for {output_filename} but no Location header was found.")
-            
-        usage_logger.info(f"Pre-authenticated URL retrieved for {output_filename}. Waiting 2 seconds before starting download...")
-        time.sleep(2)
-        
-        max_retries = 5
-        retry_interval = 30
-        
-        for attempt in range(1, max_retries + 1):
-            try:
-                usage_logger.info(f"[Attempt {attempt}/{max_retries}] Downloading {output_filename}...")
-                with requests.get(location_url, stream=True) as csv_response:
-                    csv_response.raise_for_status()
-                    
-                    if os.path.exists(output_path):
-                        usage_logger.info(f"Notice: '{output_filename}' already exists in 'reports'. Overwriting...")
-                        
-                    with open(output_path, "wb") as f:
-                        for chunk in csv_response.iter_content(chunk_size=8192):
-                            if chunk:
-                                f.write(chunk)
-                break
-            except requests.exceptions.RequestException as e:
-                if attempt < max_retries:
-                    usage_logger.warning(f"[Attempt {attempt}/{max_retries}] Failed to download {output_filename}. Retrying in {retry_interval}s... (Error: {e})")
-                    time.sleep(retry_interval)
-                else:
-                    usage_logger.error(f"Failed to download {output_filename} after {max_retries} attempts.", exc_info=True)
-                    raise Exception(f"Failed to download {output_filename} after {max_retries} attempts. Last error: {e}")
-                    
-        usage_logger.info(f"Success! Saved usage report to: {output_path}")
-        
-    elif report_response.status_code == 200:
-        usage_logger.info(f"Unexpected 200 OK for {output_filename}. Saving payload directly via stream...")
-        if os.path.exists(output_path):
-            usage_logger.info(f"Notice: '{output_filename}' already exists in 'reports'. Overwriting...")
-            
-        with open(output_path, "wb") as f:
-            for chunk in report_response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-        report_response.close()
-        usage_logger.info(f"Success! Saved usage report to: {output_path}")
-    else:
-        usage_logger.error(f"Error fetching {output_filename}. Status Code: {report_response.status_code}")
-        report_response.close()
-        raise Exception(f"API Error {report_response.status_code} fetching {output_filename}")
-
-def _download_reports_batch(access_token, reports_to_download):
-    """Helper to download a specific list of reports in parallel."""
-    usage_logger.info(f"Starting parallel downloads for {len(reports_to_download)} reports...")
-    
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reports_to_download)) as executor:
-        futures = [executor.submit(download_report, url, access_token, filename) for url, filename in reports_to_download]
-        for future in concurrent.futures.as_completed(futures):
-            future.result()
+    service.download_reports_batch(reports, reports_dir)
+    client.close()
 
 def process_active_user_detail(filepath):
     """Streams the downloaded CSV and calculates usage counters over 30, 90, and 180 days."""
@@ -212,7 +154,7 @@ def process_active_user_counts(filepath):
     }
 
 def process_m365_app_user_detail(filepath):
-    """Streams the downloaded M365 App User Detail CSV and calculates usage counters."""
+    """Streams the downloaded CSV and calculates usage counters."""
     usage_logger.info(f"Processing M365 App file: {os.path.basename(filepath)}")
     
     if not os.path.exists(filepath):
@@ -246,32 +188,26 @@ def process_m365_app_user_detail(filepath):
 def run_o365_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for O365 Active User Data (Isolated for independent retries)."""
     usage_logger.info("Starting isolated O365 Pipeline...")
-    access_token = get_access_token(client_id, client_secret, tenant_id)
-    
     reports = [
         ("https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserDetail(period='D180')", "Office365ActiveUserDetail(180d).csv")
     ]
-    
-    _download_reports_batch(access_token, reports)
+    _download_reports_via_service(client_id, client_secret, tenant_id, reports)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
-    
     return process_active_user_detail(os.path.join(reports_dir, "Office365ActiveUserDetail(180d).csv"))
 
 def run_o365_trend_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for O365 Trend Data (Isolated for independent retries)."""
     try:
         usage_logger.info("Starting isolated O365 Trend Pipeline...")
-        access_token = get_access_token(client_id, client_secret, tenant_id)
         reports = [
             ("https://graph.microsoft.com/v1.0/reports/getOffice365ActiveUserCounts(period='D30')", "Office365ActiveUserCounts(30d).csv")
         ]
-        _download_reports_batch(access_token, reports)
+        _download_reports_via_service(client_id, client_secret, tenant_id, reports)
         
         script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
         reports_dir = os.path.join(script_dir, "reports")
-        
         return process_active_user_counts(os.path.join(reports_dir, "Office365ActiveUserCounts(30d).csv"))
     except Exception as e:
         usage_logger.error("O365 Trend pipeline failed.", exc_info=True)
@@ -280,16 +216,12 @@ def run_o365_trend_pipeline(client_id, client_secret, tenant_id):
 def run_m365_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for M365 Apps Data (Isolated for independent retries)."""
     usage_logger.info("Starting isolated M365 Apps Pipeline...")
-    access_token = get_access_token(client_id, client_secret, tenant_id)
-    
     reports = [
         ("https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(period='D180')", "M365AppUserDetail(180d).csv"),
         ("https://graph.microsoft.com/v1.0/reports/getM365AppUserCounts(period='D180')", "getM365AppUserCounts(180d).csv")
     ]
-    
-    _download_reports_batch(access_token, reports)
+    _download_reports_via_service(client_id, client_secret, tenant_id, reports)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
-    
     return process_m365_app_user_detail(os.path.join(reports_dir, "M365AppUserDetail(180d).csv"))

--- a/telemetry/active_users_usage.py
+++ b/telemetry/active_users_usage.py
@@ -36,6 +36,7 @@ def _get_reports_service(client_id, client_secret, tenant_id) -> tuple[GraphClie
         retries=5,
         backoff=2
     )
+    client.authenticate()
     return client, ReportsService(client)
 
 def process_active_user_detail(filepath):

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -17,6 +17,10 @@ import customtkinter as ctk
 from telemetry import active_users_usage as usage
 from telemetry.sharepoint_onedrive_usage import SharePointOneDriveUsageFrame
 
+# Import unified core service layer
+from core.graph.client import GraphClient
+from core.graph.directory import DirectoryService
+
 # Safely import matplotlib to embed plots in Tkinter
 try:
     import matplotlib.pyplot as plt
@@ -310,67 +314,26 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
             
             self.log_msg(f"Authenticating app {client_id[:5]}...")
             
-            session = requests.Session()
-            retries = Retry(
-                total=self.retries.get(),
-                backoff_factor=self.backoff.get(),
-                status_forcelist=[500, 502, 503, 504],
-                allowed_methods=["GET", "POST"],
+            client = GraphClient(
+                tenant_id=tenant,
+                client_ids=client_id,
+                client_secrets=client_secret,
+                concurrency=1,
+                retries=self.retries.get(),
+                backoff=self.backoff.get()
             )
-            adapter = HTTPAdapter(max_retries=retries)
-            session.mount("https://", adapter)
             
-            token_url = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
-            token_data = {
-                "grant_type": "client_credentials",
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "scope": "https://graph.microsoft.com/.default"
-            }
-            
-            resp = session.post(token_url, data=token_data, timeout=30)
-            resp.raise_for_status()
-            access_token = resp.json().get("access_token")
-            
-            # Verify permissions logic
+            # Re-use the GraphClient parallel scope verification inside core service client
             required_scopes = ["Organization.Read.All", "Directory.Read.All"]
-            payload_part = access_token.split(".")[1]
-            payload_part += "=" * (-len(payload_part) % 4)
-            decoded_bytes = base64.urlsafe_b64decode(payload_part)
-            payload = json.loads(decoded_bytes)
-
-            granted_roles = set(payload.get("roles", []))
-            missing = [s for s in required_scopes if s not in granted_roles]
-            if missing:
-                raise Exception(
-                    f"Missing Required Permissions for App {client_id[:5]}...: "
-                    f"{', '.join(missing)}\n"
-                    f"Current Assigned Roles: {', '.join(granted_roles)}\n"
-                    "Please grant these Application permissions in Azure Portal."
-                )
-                
-            self.log_msg("Querying Graph API endpoint for SKUs...")
-            headers = {
-                "Authorization": f"Bearer {access_token}", 
-                "ConsistencyLevel": "eventual"
-            }
-            response = session.get(f"{GRAPH_BASE_URL}/subscribedSkus", headers=headers, timeout=30)
+            client.authenticate(required_scopes=required_scopes)
             
-            if response.status_code == 200:
-                sku_data = response.json()
-                async_logger.info("Successfully fetched SKU data.")
-                self.after(0, self._render_skus_success, sku_data)
-            else:
-                err_string = f"API Fetch Error [{response.status_code}]: {response.text}"
-                async_logger.error(err_string)
-                self.after(0, self._render_skus_error, err_string)
-
-        except requests.exceptions.RequestException as e:
-            err_msg = f"Network/Auth Error: {e}"
-            if e.response is not None:
-                err_msg += f" - {e.response.text}"
-            async_logger.error(err_msg, exc_info=True)
-            self.after(0, self._render_skus_error, err_msg)
+            self.log_msg("Querying Graph API endpoint for SKUs...")
+            dir_service = DirectoryService(client)
+            sku_data = dir_service.get_subscribed_skus()
+            client.close()
+            
+            async_logger.info("Successfully fetched SKU data.")
+            self.after(0, self._render_skus_success, sku_data)
         except Exception as e:
             async_logger.error("Exception caught in _execute_sku_worker.", exc_info=True)
             self.after(0, self._render_skus_error, str(e))

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -55,26 +55,7 @@ async_logger.propagate = False
 
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 
-COLOR_PRIMARY = "#0B57D0"
-COLOR_SURFACE = "#FFFFFF"
-COLOR_TEXT_MAIN = "#1F1F1F"
-COLOR_TEXT_SUB = "#444746"
-COLOR_OUTLINE = "#747775"
-COLOR_OUTLINE_LIGHT = "#E0E2E0"
-COLOR_TONAL_BG = "#D3E3FD"
-COLOR_TONAL_TEXT = "#041E49"
-COLOR_SUCCESS = "#188038"
-COLOR_ERROR = "#B3261E"
-COLOR_PRIMARY_HOVER = "#0842a0"
-COLOR_SECONDARY_HOVER = "#F1F3F4"
-COLOR_SURFACE_HOVER = "#EFF6FF"
-COLOR_SURFACE_VARIANT = "#F8F9FA"
-
-FONT_HEADER_MEDIUM = ("Roboto", 24, "bold")
-FONT_HEADER_SMALL = ("Roboto", 18, "bold")
-FONT_BODY_BOLD = ("Roboto", 14, "bold")
-FONT_BODY_MEDIUM = ("Roboto", 12)
-FONT_BODY_SMALL = ("Roboto", 11)
+from telemetry.styles import *
 
 
 class LicenseUsageTab(ctk.CTkScrollableFrame):

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 import customtkinter as ctk
 
 from telemetry import active_users_usage as usage
+from telemetry.sharepoint_onedrive_usage import SharePointOneDriveUsageFrame
 
 # Safely import matplotlib to embed plots in Tkinter
 try:
@@ -186,6 +187,14 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.m365_state_frame = ctk.CTkFrame(self.m365_section, fg_color="transparent")
         self.m365_grid_frame = ctk.CTkFrame(self.m365_section, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
 
+        # 5. SharePoint & OneDrive Telemetry Section (Modular Integration)
+        self.sp_od_view = SharePointOneDriveUsageFrame(
+            master=self,
+            log_callback=self.log_msg,
+            credentials_callback=self._get_credentials,
+            status_change_callback=self._check_all_done
+        )
+
         self._hide_all_grids()
 
     # -------------------------------------------------------------------------
@@ -196,6 +205,7 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.o365_section.pack_forget()
         self.o365_trend_section.pack_forget()
         self.m365_section.pack_forget()
+        self.sp_od_view.reset_view()
 
         for grid in [self.lic_grid_frame, self.o365_grid_frame, self.o365_trend_grid_frame, self.m365_grid_frame]:
             for w in grid.winfo_children():
@@ -226,7 +236,7 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
 
     def _check_all_done(self):
         """Checks if all sections have resolved (success or error) and updates main UI."""
-        states = [self.status_sku, self.status_o365, self.status_o365_trend, self.status_m365]
+        states = [self.status_sku, self.status_o365, self.status_o365_trend, self.status_m365, self.sp_od_view.status]
 
         if "loading" in states:
             return
@@ -259,6 +269,7 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.retry_o365(clear_log=False)
         self.retry_o365_trend(clear_log=False)
         self.retry_m365(clear_log=False)
+        self.sp_od_view.trigger_fetch(tenant, clients[0], secrets[0])
 
     # -------------------------------------------------------------------------
     # INDIVIDUAL RETRY HANDLERS

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -143,6 +143,7 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
         retries=5,
         backoff=2
     )
+    client.authenticate()
     service = ReportsService(client)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -1,0 +1,385 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Modular SharePoint and OneDrive usage telemetry scanner and visual interface."""
+
+import os
+import csv
+import requests
+import concurrent.futures
+import time
+import logging
+import threading
+import customtkinter as ctk
+
+# Bind to the async logger initialized in license_usage.py
+usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
+
+# =================================================================================
+# CONSTANTS & STYLES (Material 3 parity with license_usage.py)
+# =================================================================================
+COLOR_PRIMARY = "#0B57D0"
+COLOR_SURFACE = "#FFFFFF"
+COLOR_TEXT_MAIN = "#1F1F1F"
+COLOR_TEXT_SUB = "#444746"
+COLOR_OUTLINE = "#747775"
+COLOR_OUTLINE_LIGHT = "#E0E2E0"
+COLOR_TONAL_BG = "#D3E3FD"
+COLOR_TONAL_TEXT = "#041E49"
+COLOR_SUCCESS = "#188038"
+COLOR_ERROR = "#B3261E"
+COLOR_PRIMARY_HOVER = "#0842a0"
+COLOR_SECONDARY_HOVER = "#F1F3F4"
+COLOR_SURFACE_HOVER = "#EFF6FF"
+COLOR_SURFACE_VARIANT = "#F8F9FA"
+
+FONT_HEADER_SMALL = ("Roboto", 18, "bold")
+FONT_BODY_BOLD = ("Roboto", 14, "bold")
+FONT_BODY_MEDIUM = ("Roboto", 12)
+FONT_BODY_SMALL = ("Roboto", 11)
+
+# =================================================================================
+# NETWORKING & PIPELINE UTILITIES (Isolated)
+# =================================================================================
+
+def get_access_token(client_id, client_secret, tenant_id):
+    """Fetches the OAuth 2.0 Access Token from Microsoft Entra ID."""
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    token_data = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": "https://graph.microsoft.com/.default"
+    }
+    usage_logger.info("Fetching OAuth token from Microsoft Entra ID for SharePoint & OneDrive...")
+    token_response = requests.post(token_url, data=token_data)
+    token_response.raise_for_status()
+    return token_response.json().get("access_token")
+
+def download_report(api_url, access_token, output_filename):
+    """Calls the Graph API and downloads the CSV report to the 'reports' folder using a streaming download."""
+    headers = {
+        "Authorization": f"Bearer {access_token}"
+    }
+    
+    usage_logger.info(f"Calling API for {output_filename} (intercepting redirect)...")
+    report_response = requests.get(api_url, headers=headers, allow_redirects=False, stream=True)
+    
+    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
+    reports_dir = os.path.join(script_dir, "reports")
+    os.makedirs(reports_dir, exist_ok=True)
+    
+    output_path = os.path.join(reports_dir, output_filename)
+    
+    if report_response.status_code == 302:
+        report_response.close()
+        location_url = report_response.headers.get("Location")
+        if not location_url:
+            usage_logger.error(f"Received a 302 status for {output_filename} but no Location header was found.")
+            raise Exception(f"Received a 302 status for {output_filename} but no Location header was found.")
+            
+        usage_logger.info(f"Pre-authenticated URL retrieved for {output_filename}. Waiting 2 seconds before starting download...")
+        time.sleep(2)
+        
+        max_retries = 5
+        retry_interval = 30
+        
+        for attempt in range(1, max_retries + 1):
+            try:
+                usage_logger.info(f"[Attempt {attempt}/{max_retries}] Downloading {output_filename}...")
+                with requests.get(location_url, stream=True) as csv_response:
+                    csv_response.raise_for_status()
+                    with open(output_path, "wb") as f:
+                        for chunk in csv_response.iter_content(chunk_size=8192):
+                            if chunk:
+                                f.write(chunk)
+                break
+            except requests.exceptions.RequestException as e:
+                if attempt < max_retries:
+                    usage_logger.warning(f"[Attempt {attempt}/{max_retries}] Failed to download {output_filename}. Retrying in {retry_interval}s... (Error: {e})")
+                    time.sleep(retry_interval)
+                else:
+                    usage_logger.error(f"Failed to download {output_filename} after {max_retries} attempts.", exc_info=True)
+                    raise Exception(f"Failed to download {output_filename} after {max_retries} attempts. Last error: {e}")
+                    
+        usage_logger.info(f"Success! Saved usage report to: {output_path}")
+        
+    elif report_response.status_code == 200:
+        usage_logger.info(f"Unexpected 200 OK for {output_filename}. Saving payload directly via stream...")
+        with open(output_path, "wb") as f:
+            for chunk in report_response.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+        report_response.close()
+        usage_logger.info(f"Success! Saved usage report to: {output_path}")
+    else:
+        usage_logger.error(f"Error fetching {output_filename}. Status Code: {report_response.status_code}")
+        report_response.close()
+        raise Exception(f"API Error {report_response.status_code} fetching {output_filename}")
+
+def format_bytes(num_bytes: int) -> str:
+    """Formats raw byte values into highly readable string equivalents (e.g., GB, TB)."""
+    if num_bytes is None:
+        return "0.00 Bytes"
+    
+    for unit in ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB']:
+        if num_bytes < 1024.0:
+            return f"{num_bytes:,.2f} {unit}"
+        num_bytes /= 1024.0
+    return f"{num_bytes:,.2f} EB"
+
+def parse_sharepoint_csv(filepath):
+    """Streams the SharePoint Site Usage Detail CSV and aggregates metrics."""
+    usage_logger.info(f"Processing SharePoint Site Usage file: {os.path.basename(filepath)}")
+    if not os.path.exists(filepath):
+        usage_logger.error(f"Error: Could not find SharePoint report {filepath}")
+        raise FileNotFoundError(f"SharePoint Site Usage report not found.")
+
+    total_sites = 0
+    total_storage = 0
+    total_files = 0
+    active_files = 0
+
+    with open(filepath, mode="r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("Is Deleted", "").strip().upper() != "TRUE":
+                total_sites += 1
+                
+                try:
+                    total_storage += int(row.get("Storage Used (Byte)", 0) or 0)
+                except ValueError:
+                    pass
+                
+                try:
+                    total_files += int(row.get("File Count", 0) or 0)
+                except ValueError:
+                    pass
+                
+                try:
+                    active_files += int(row.get("Active File Count", 0) or 0)
+                except ValueError:
+                    pass
+                    
+    return {
+        "total_sites": total_sites,
+        "total_storage_bytes": total_storage,
+        "total_storage_formatted": format_bytes(total_storage),
+        "total_files": total_files,
+        "active_files": active_files,
+        "active_files_pct": (active_files / total_files * 100) if total_files > 0 else 0.0
+    }
+
+def parse_onedrive_csv(filepath):
+    """Streams the OneDrive Account Usage Detail CSV and aggregates metrics."""
+    usage_logger.info(f"Processing OneDrive Account Usage file: {os.path.basename(filepath)}")
+    if not os.path.exists(filepath):
+        usage_logger.error(f"Error: Could not find OneDrive report {filepath}")
+        raise FileNotFoundError(f"OneDrive Account Usage report not found.")
+
+    total_accounts = 0
+    total_storage = 0
+    total_files = 0
+    active_files = 0
+
+    with open(filepath, mode="r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("Is Deleted", "").strip().upper() != "TRUE":
+                total_accounts += 1
+                
+                try:
+                    total_storage += int(row.get("Storage Used (Byte)", 0) or 0)
+                except ValueError:
+                    pass
+                
+                try:
+                    total_files += int(row.get("File Count", 0) or 0)
+                except ValueError:
+                    pass
+                
+                try:
+                    active_files += int(row.get("Active File Count", 0) or 0)
+                except ValueError:
+                    pass
+                    
+    return {
+        "total_accounts": total_accounts,
+        "total_storage_bytes": total_storage,
+        "total_storage_formatted": format_bytes(total_storage),
+        "total_files": total_files,
+        "active_files": active_files,
+        "active_files_pct": (active_files / total_files * 100) if total_files > 0 else 0.0
+    }
+
+def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
+    """Pipeline specifically for SharePoint and OneDrive telemetry data collection."""
+    usage_logger.info("Starting SharePoint & OneDrive Telemetry Pipeline...")
+    access_token = get_access_token(client_id, client_secret, tenant_id)
+    
+    reports = [
+        ("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv"),
+        ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv")
+    ]
+    
+    # Parallel downloads inside isolated thread executor
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(download_report, url, access_token, filename) for url, filename in reports]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+    
+    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
+    reports_dir = os.path.join(script_dir, "reports")
+    
+    sp_data = parse_sharepoint_csv(os.path.join(reports_dir, "SharePointSiteUsageDetail(180d).csv"))
+    od_data = parse_onedrive_csv(os.path.join(reports_dir, "OneDriveUsageAccountDetail(180d).csv"))
+    
+    return {
+        "sharepoint": sp_data,
+        "onedrive": od_data
+    }
+
+# =================================================================================
+# CUSTOM UI COMPONENT CLASS
+# =================================================================================
+
+class SharePointOneDriveUsageFrame(ctk.CTkFrame):
+    """Self-contained customtkinter component wrapping SharePoint & OneDrive Telemetry UI."""
+    
+    def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
+        super().__init__(master, fg_color="transparent", **kwargs)
+        self.log_msg = log_callback
+        self.get_credentials = credentials_callback
+        self.on_status_change = status_change_callback
+        self.status = None  # 'loading', 'success', 'error', None
+        
+        self.build_ui()
+
+    def build_ui(self):
+        """Creates card container for the tab."""
+        self.pack(fill="x", expand=True, pady=(20, 10))
+        
+        ctk.CTkLabel(self, text="SharePoint & OneDrive Telemetry (180 Days)", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
+        
+        self.state_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.grid_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        self.reset_view()
+
+    def reset_view(self):
+        """Resets and hides grids."""
+        self.pack_forget()
+        self.state_frame.pack_forget()
+        self.grid_frame.pack_forget()
+        
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+    def _set_state_loading(self, msg="Loading..."):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _set_state_error(self, error_msg):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM).pack(pady=(20, 10))
+        ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _retry_fetch(self):
+        tenant, clients, secrets = self.get_credentials()
+        if tenant:
+            self.trigger_fetch(tenant, clients[0], secrets[0])
+
+    def trigger_fetch(self, tenant, client_id, client_secret):
+        """Triggers parallel fetches inside isolated background threads."""
+        self.status = "loading"
+        self.on_status_change()
+        
+        self.pack(fill="x", expand=True, pady=(20, 10))
+        self.grid_frame.pack_forget()
+        
+        self._set_state_loading("Downloading and parsing SharePoint & OneDrive reports...")
+        
+        threading.Thread(
+            target=self._execute_worker,
+            args=(tenant, client_id, client_secret),
+            daemon=True
+        ).start()
+
+    def _execute_worker(self, tenant: str, client_id: str, client_secret: str):
+        usage_logger.info("Executing thread: _execute_sp_od_worker")
+        try:
+            data = run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant)
+            usage_logger.info("Successfully completed SharePoint & OneDrive telemetry data fetch.")
+            self.after(0, self._render_success, data)
+        except Exception as e:
+            usage_logger.error("Exception caught in SharePoint & OneDrive worker.", exc_info=True)
+            self.after(0, self._render_error, str(e))
+
+    def _render_success(self, data: dict):
+        self.state_frame.pack_forget()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+        self.grid_frame.pack(fill="x", expand=True)
+
+        self.grid_frame.grid_columnconfigure(0, weight=2)
+        self.grid_frame.grid_columnconfigure(1, weight=1)
+        self.grid_frame.grid_columnconfigure(2, weight=1)
+
+        headers_sp_od = ["Metric Description", "SharePoint Sites", "OneDrive Accounts"]
+        for col_idx, head_text in enumerate(headers_sp_od):
+            cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
+            cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+        sp = data.get("sharepoint", {})
+        od = data.get("onedrive", {})
+
+        rows_data = [
+            ("Total Count", f"{sp.get('total_sites', 0):,} Sites", f"{od.get('total_accounts', 0):,} Accounts"),
+            ("Total Storage Used", sp.get("total_storage_formatted", "0.00 Bytes"), od.get("total_storage_formatted", "0.00 Bytes")),
+            ("Total File Count", f"{sp.get('total_files', 0):,} Files", f"{od.get('total_files', 0):,} Files"),
+            ("Active File Count", 
+             f"{sp.get('active_files', 0):,} Files ({sp.get('active_files_pct', 0.0):.1f}%)", 
+             f"{od.get('active_files', 0):,} Files ({od.get('active_files_pct', 0.0):.1f}%)")
+        ]
+
+        for r_idx, (metric_name, sp_val, od_val) in enumerate(rows_data, start=1):
+            bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+            
+            c0 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c0.grid(row=r_idx, column=0, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(c0, text=metric_name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+            c1 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(c1, text=sp_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+            c2 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(c2, text=od_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+        self.status = "success"
+        self.on_status_change()
+
+    def _render_error(self, err_msg):
+        self._set_state_error(err_msg)
+        self.status = "error"
+        self.on_status_change()

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -16,12 +16,12 @@
 
 import os
 import csv
-import requests
-import concurrent.futures
-import time
 import logging
 import threading
 import customtkinter as ctk
+
+# Import pre-existing, resilient network and batch helpers directly from the core package
+from telemetry import active_users_usage as usage
 
 # Bind to the async logger initialized in license_usage.py
 usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
@@ -50,83 +50,8 @@ FONT_BODY_MEDIUM = ("Roboto", 12)
 FONT_BODY_SMALL = ("Roboto", 11)
 
 # =================================================================================
-# NETWORKING & PIPELINE UTILITIES (Isolated)
+# PIPELINE UTILITIES
 # =================================================================================
-
-def get_access_token(client_id, client_secret, tenant_id):
-    """Fetches the OAuth 2.0 Access Token from Microsoft Entra ID."""
-    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-    token_data = {
-        "grant_type": "client_credentials",
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "scope": "https://graph.microsoft.com/.default"
-    }
-    usage_logger.info("Fetching OAuth token from Microsoft Entra ID for SharePoint & OneDrive...")
-    token_response = requests.post(token_url, data=token_data)
-    token_response.raise_for_status()
-    return token_response.json().get("access_token")
-
-def download_report(api_url, access_token, output_filename):
-    """Calls the Graph API and downloads the CSV report to the 'reports' folder using a streaming download."""
-    headers = {
-        "Authorization": f"Bearer {access_token}"
-    }
-    
-    usage_logger.info(f"Calling API for {output_filename} (intercepting redirect)...")
-    report_response = requests.get(api_url, headers=headers, allow_redirects=False, stream=True)
-    
-    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
-    reports_dir = os.path.join(script_dir, "reports")
-    os.makedirs(reports_dir, exist_ok=True)
-    
-    output_path = os.path.join(reports_dir, output_filename)
-    
-    if report_response.status_code == 302:
-        report_response.close()
-        location_url = report_response.headers.get("Location")
-        if not location_url:
-            usage_logger.error(f"Received a 302 status for {output_filename} but no Location header was found.")
-            raise Exception(f"Received a 302 status for {output_filename} but no Location header was found.")
-            
-        usage_logger.info(f"Pre-authenticated URL retrieved for {output_filename}. Waiting 2 seconds before starting download...")
-        time.sleep(2)
-        
-        max_retries = 5
-        retry_interval = 30
-        
-        for attempt in range(1, max_retries + 1):
-            try:
-                usage_logger.info(f"[Attempt {attempt}/{max_retries}] Downloading {output_filename}...")
-                with requests.get(location_url, stream=True) as csv_response:
-                    csv_response.raise_for_status()
-                    with open(output_path, "wb") as f:
-                        for chunk in csv_response.iter_content(chunk_size=8192):
-                            if chunk:
-                                f.write(chunk)
-                break
-            except requests.exceptions.RequestException as e:
-                if attempt < max_retries:
-                    usage_logger.warning(f"[Attempt {attempt}/{max_retries}] Failed to download {output_filename}. Retrying in {retry_interval}s... (Error: {e})")
-                    time.sleep(retry_interval)
-                else:
-                    usage_logger.error(f"Failed to download {output_filename} after {max_retries} attempts.", exc_info=True)
-                    raise Exception(f"Failed to download {output_filename} after {max_retries} attempts. Last error: {e}")
-                    
-        usage_logger.info(f"Success! Saved usage report to: {output_path}")
-        
-    elif report_response.status_code == 200:
-        usage_logger.info(f"Unexpected 200 OK for {output_filename}. Saving payload directly via stream...")
-        with open(output_path, "wb") as f:
-            for chunk in report_response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-        report_response.close()
-        usage_logger.info(f"Success! Saved usage report to: {output_path}")
-    else:
-        usage_logger.error(f"Error fetching {output_filename}. Status Code: {report_response.status_code}")
-        report_response.close()
-        raise Exception(f"API Error {report_response.status_code} fetching {output_filename}")
 
 def format_bytes(num_bytes: int) -> str:
     """Formats raw byte values into highly readable string equivalents (e.g., GB, TB)."""
@@ -226,18 +151,17 @@ def parse_onedrive_csv(filepath):
 def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for SharePoint and OneDrive telemetry data collection."""
     usage_logger.info("Starting SharePoint & OneDrive Telemetry Pipeline...")
-    access_token = get_access_token(client_id, client_secret, tenant_id)
+    
+    # Re-use core Entra ID token retriever
+    access_token = usage.get_access_token(client_id, client_secret, tenant_id)
     
     reports = [
         ("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv"),
         ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv")
     ]
     
-    # Parallel downloads inside isolated thread executor
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [executor.submit(download_report, url, access_token, filename) for url, filename in reports]
-        for future in concurrent.futures.as_completed(futures):
-            future.result()
+    # Re-use parallel batch stream downloader
+    usage._download_reports_batch(access_token, reports)
     
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
@@ -251,9 +175,8 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     }
 
 # =================================================================================
-# CUSTOM UI COMPONENT CLASS
+# CUSTOM UI COMPONENT CLASS (Preserved identically for visual parity)
 # =================================================================================
-
 class SharePointOneDriveUsageFrame(ctk.CTkFrame):
     """Self-contained customtkinter component wrapping SharePoint & OneDrive Telemetry UI."""
     

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -20,8 +20,9 @@ import logging
 import threading
 import customtkinter as ctk
 
-# Import pre-existing, resilient network and batch helpers directly from the core package
-from telemetry import active_users_usage as usage
+# Import unified core service layer
+from core.graph.client import GraphClient
+from core.graph.reports import ReportsService
 
 # Bind to the async logger initialized in license_usage.py
 usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
@@ -134,19 +135,26 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     """Pipeline specifically for SharePoint and OneDrive telemetry data collection."""
     usage_logger.info("Starting SharePoint & OneDrive Telemetry Pipeline...")
     
-    # Re-use core Entra ID token retriever
-    access_token = usage.get_access_token(client_id, client_secret, tenant_id)
+    client = GraphClient(
+        tenant_id=tenant_id,
+        client_ids=client_id,
+        client_secrets=client_secret,
+        concurrency=2,
+        retries=5,
+        backoff=2
+    )
+    service = ReportsService(client)
     
     reports = [
         ("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv"),
         ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv")
     ]
     
-    # Re-use parallel batch stream downloader
-    usage._download_reports_batch(access_token, reports)
-    
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
+    
+    service.download_reports_batch(reports, reports_dir)
+    client.close()
     
     sp_data = parse_sharepoint_csv(os.path.join(reports_dir, "SharePointSiteUsageDetail(180d).csv"))
     od_data = parse_onedrive_csv(os.path.join(reports_dir, "OneDriveUsageAccountDetail(180d).csv"))

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -27,27 +27,9 @@ from telemetry import active_users_usage as usage
 usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
 
 # =================================================================================
-# CONSTANTS & STYLES (Material 3 parity with license_usage.py)
+# CONSTANTS & STYLES (Imported from shared styles)
 # =================================================================================
-COLOR_PRIMARY = "#0B57D0"
-COLOR_SURFACE = "#FFFFFF"
-COLOR_TEXT_MAIN = "#1F1F1F"
-COLOR_TEXT_SUB = "#444746"
-COLOR_OUTLINE = "#747775"
-COLOR_OUTLINE_LIGHT = "#E0E2E0"
-COLOR_TONAL_BG = "#D3E3FD"
-COLOR_TONAL_TEXT = "#041E49"
-COLOR_SUCCESS = "#188038"
-COLOR_ERROR = "#B3261E"
-COLOR_PRIMARY_HOVER = "#0842a0"
-COLOR_SECONDARY_HOVER = "#F1F3F4"
-COLOR_SURFACE_HOVER = "#EFF6FF"
-COLOR_SURFACE_VARIANT = "#F8F9FA"
-
-FONT_HEADER_SMALL = ("Roboto", 18, "bold")
-FONT_BODY_BOLD = ("Roboto", 14, "bold")
-FONT_BODY_MEDIUM = ("Roboto", 12)
-FONT_BODY_SMALL = ("Roboto", 11)
+from telemetry.styles import *
 
 # =================================================================================
 # PIPELINE UTILITIES

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -145,15 +145,10 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     )
     service = ReportsService(client)
     
-    reports = [
-        ("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv"),
-        ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv")
-    ]
-    
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
     
-    service.download_reports_batch(reports, reports_dir)
+    service.download_sharepoint_onedrive_details(reports_dir)
     client.close()
     
     sp_data = parse_sharepoint_csv(os.path.join(reports_dir, "SharePointSiteUsageDetail(180d).csv"))

--- a/telemetry/styles.py
+++ b/telemetry/styles.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared Material 3 style constants and typography tokens for the Telemetry module."""
+
+COLOR_PRIMARY = "#0B57D0"
+COLOR_SURFACE = "#FFFFFF"
+COLOR_TEXT_MAIN = "#1F1F1F"
+COLOR_TEXT_SUB = "#444746"
+COLOR_OUTLINE = "#747775"
+COLOR_OUTLINE_LIGHT = "#E0E2E0"
+COLOR_TONAL_BG = "#D3E3FD"
+COLOR_TONAL_TEXT = "#041E49"
+COLOR_SUCCESS = "#188038"
+COLOR_ERROR = "#B3261E"
+COLOR_PRIMARY_HOVER = "#0842a0"
+COLOR_SECONDARY_HOVER = "#F1F3F4"
+COLOR_SURFACE_HOVER = "#EFF6FF"
+COLOR_SURFACE_VARIANT = "#F8F9FA"
+
+FONT_HEADER_MEDIUM = ("Roboto", 24, "bold")
+FONT_HEADER_SMALL = ("Roboto", 18, "bold")
+FONT_BODY_BOLD = ("Roboto", 14, "bold")
+FONT_BODY_MEDIUM = ("Roboto", 12)
+FONT_BODY_SMALL = ("Roboto", 11)


### PR DESCRIPTION
This pull request adds SharePoint and OneDrive usage telemetry metrics (including storage format, total sites/accounts, file counts, active file counts/percentages) to the M365 License & Usage overview dashboard.