### PR TITLE
refactor: establish unified core/graph Microsoft Graph API service layer

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified Microsoft Graph API service layer."""

--- a/core/graph/client.py
+++ b/core/graph/client.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified client managing connection pools, authentication, and sessions for Microsoft Graph."""
+
+import logging
+from typing import List, Dict, Any, Union, Optional
+import requests
+from util.auth_manager import TokenManager
+from util.connectors import UrlInvoker
+
+logger = logging.getLogger(__name__)
+
+class GraphClient:
+    """Unified client managing credentials validation and connection slots to Microsoft Graph."""
+
+    def __init__(
+        self,
+        tenant_id: str,
+        client_ids: Union[str, List[str]],
+        client_secrets: Union[str, List[str]],
+        concurrency: int = 1,
+        retries: int = 5,
+        backoff: int = 2
+    ) -> None:
+        self.tenant_id = tenant_id
+        
+        # Normalize inputs to lists to perfectly match TokenManager parameters
+        self.client_ids = [client_ids] if isinstance(client_ids, str) else client_ids
+        self.client_secrets = [client_secrets] if isinstance(client_secrets, str) else client_secrets
+        
+        self.token_manager = TokenManager(
+            tenant_id=self.tenant_id,
+            client_ids=self.client_ids,
+            client_secrets=self.client_secrets,
+            concurrency=concurrency,
+            retries=retries,
+            backoff=backoff
+        )
+
+        self.url_invoker = UrlInvoker(
+            token_manager=self.token_manager,
+            batch_retry_count=retries,
+            batch_backoff=backoff,
+            initial_delay=1,
+            jitter=0.5
+        )
+
+    def authenticate(self, required_scopes: Optional[List[str]] = None) -> None:
+        """Validates Entra ID scopes and fetches active tokens."""
+        self.token_manager.authenticate_all(required_scopes=required_scopes)
+
+    def get_session(self) -> requests.Session:
+        """Returns the unified requests Session pool."""
+        return self.token_manager.get_session()
+
+    def get_active_token(self) -> Dict[str, Any]:
+        """Acquires an active, refreshed token slot from TokenManager lease queue."""
+        return self.token_manager.get_valid_token_slot()
+
+    def release_token(self, token_slot: Dict[str, Any]) -> None:
+        """Returns token slot to the queue, completing the lease cycle."""
+        self.token_manager.return_token_slot(token_slot)
+
+    def close(self) -> None:
+        """Releases all connection pool and socket resources."""
+        self.token_manager.close()
+
+    def __enter__(self) -> "GraphClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/core/graph/directory.py
+++ b/core/graph/directory.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DirectoryService for querying tenant details and subscribed SKUs config."""
+
+import logging
+from typing import Dict, Any
+from core.graph.client import GraphClient
+
+logger = logging.getLogger(__name__)
+
+class DirectoryService:
+    """Service to query Entra ID directory configuration details."""
+
+    def __init__(self, client: GraphClient) -> None:
+        self.client = client
+
+    def get_subscribed_skus(self) -> Dict[str, Any]:
+        """Queries the Microsoft Graph /subscribedSkus endpoint with active retries."""
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}",
+            "ConsistencyLevel": "eventual"
+        }
+        try:
+            url = "https://graph.microsoft.com/v1.0/subscribedSkus"
+            logger.info("Querying Graph API configuration endpoint: %s", url)
+            resp = session.get(url, headers=headers, timeout=30.0)
+            resp.raise_for_status()
+            return resp.json()
+        finally:
+            self.client.release_token(token_slot)

--- a/core/graph/reports.py
+++ b/core/graph/reports.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ReportsService encapsulating Microsoft Graph usage report generation and downloads."""
+
+import os
+import time
+import logging
+import concurrent.futures
+from typing import List, Tuple
+import requests
+from core.graph.client import GraphClient
+
+logger = logging.getLogger(__name__)
+
+class ReportsService:
+    """Service to fetch streaming M365 telemetry reports via Microsoft Graph API."""
+
+    def __init__(self, client: GraphClient) -> None:
+        self.client = client
+
+    def download_report(self, api_url: str, output_filename: str, output_dir: str) -> None:
+        """Downloads a single CSV report via a streaming connection utilizing GraphClient session."""
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+        
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}"
+        }
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, output_filename)
+
+        try:
+            logger.info("Calling Graph report endpoint for %s...", output_filename)
+            resp = session.get(api_url, headers=headers, allow_redirects=False, stream=True)
+            
+            # Graph APIs return status code 302 redirect to a pre-authenticated S3/Azure Blob URL
+            if resp.status_code == 302:
+                resp.close()
+                location_url = resp.headers.get("Location")
+                if not location_url:
+                    raise ConnectionError(f"302 redirect returned for {output_filename} but Location header is missing.")
+                
+                logger.info("Pre-authenticated storage redirect retrieved. Waiting 2 seconds before download...")
+                time.sleep(2)
+
+                max_retries = 5
+                retry_interval = 30
+                for attempt in range(1, max_retries + 1):
+                    try:
+                        logger.info("[Attempt %d/%d] Downloading report stream to %s...", attempt, max_retries, output_filename)
+                        with requests.get(location_url, stream=True) as download_stream:
+                            download_stream.raise_for_status()
+                            with open(output_path, "wb") as f:
+                                for chunk in download_stream.iter_content(chunk_size=8192):
+                                    if chunk:
+                                        f.write(chunk)
+                        break
+                    except requests.exceptions.RequestException as error:
+                        if attempt < max_retries:
+                            logger.warning("[Attempt %d/%d] Failed stream download. Retrying in %ds... (Error: %s)", attempt, max_retries, retry_interval, error)
+                            time.sleep(retry_interval)
+                        else:
+                            logger.error("Failed downloading %s after %d attempts.", output_filename, max_retries, exc_info=True)
+                            raise ConnectionError(f"Failed downloading report after {max_retries} attempts. Details: {error}")
+                
+                logger.info("Success! Saved report to: %s", output_path)
+
+            elif resp.status_code == 200:
+                logger.info("Unexpected 200 OK status returned. Saving direct streaming stream...")
+                with open(output_path, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                resp.close()
+                logger.info("Success! Saved report to: %s", output_path)
+            else:
+                resp.close()
+                logger.error("Graph report request failed with status code %d: %s", resp.status_code, resp.text)
+                raise ConnectionError(f"Microsoft Graph API request failed with status code {resp.status_code}")
+        finally:
+            self.client.release_token(token_slot)
+
+    def download_reports_batch(self, reports: List[Tuple[str, str]], output_dir: str) -> None:
+        """Downloads a list of reports concurrently using thread executors."""
+        logger.info("Starting parallel batch download for %d reports...", len(reports))
+        
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(reports)) as executor:
+            futures = [
+                executor.submit(self.download_report, url, filename, output_dir)
+                for url, filename in reports
+            ]
+            # Gather all futures, raising exceptions if any thread failed
+            for future in concurrent.futures.as_completed(futures):
+                future.result()

--- a/estimators/factory.py
+++ b/estimators/factory.py
@@ -1,3 +1,4 @@
+from core.graph.client import GraphClient
 from estimators.chat_estimator import ChatEstimator
 from estimators.eo_group_mailbox_estimator import EOGroupMailBoxEstimator
 from estimators.eo_in_place_archive_estimator import EOInPlaceArchiveEstimator
@@ -14,11 +15,13 @@ class EstimatorFactory:
   def __init__(
     self,
     config: ScanConfig,
+    client: GraphClient = None,
     manager: TokenManager = None,
     logger = None,
     stop_event = None,
     id_to_display_name = None
   ):
+    self.client = client
     self.manager = manager
     self.config = config
     self.logger = logger
@@ -37,16 +40,20 @@ class EstimatorFactory:
 
   def get_manager(self):
     if not self.manager:
-      if self.isEmpty(self.config.client_ids) or self.isEmpty(self.config.client_secrets) or self.isEmpty(self.config.tenant_id):
-        raise Exception("Missing credentials for tenant scan!!")
-      self.manager = TokenManager(
-        self.config.tenant_id,
-        self.config.client_ids,
-        self.config.client_secrets,
-        self.config.concurrency,
-        self.config.retries,
-        self.config.backoff,
-      )
+      if self.client:
+        self.manager = self.client.token_manager
+      else:
+        if self.isEmpty(self.config.client_ids) or self.isEmpty(self.config.client_secrets) or self.isEmpty(self.config.tenant_id):
+          raise Exception("Missing credentials for tenant scan!!")
+        self.client = GraphClient(
+            self.config.tenant_id,
+            self.config.client_ids,
+            self.config.client_secrets,
+            self.config.concurrency,
+            self.config.retries,
+            self.config.backoff
+        )
+        self.manager = self.client.token_manager
     
     return self.manager
 
@@ -57,9 +64,13 @@ class EstimatorFactory:
 
   def get_url_invoker(self, hard_reset=False):
     if self.url_invoker is None or hard_reset:
-      self.url_invoker = UrlInvoker(
-          self.manager, self.config.retries, self.config.backoff, 1, 0.5
-      )
+      if self.client:
+        self.url_invoker = self.client.url_invoker
+      else:
+        manager = self.get_manager()
+        self.url_invoker = UrlInvoker(
+            manager, self.config.retries, self.config.backoff, 1, 0.5
+        )
 
     return self.url_invoker
 


### PR DESCRIPTION
This pull request establishes a dedicated, unified Microsoft Graph Service Layer under `core/graph`, wrapping credential validation (`TokenManager`) and robust batch executing sessions (`UrlInvoker`). Decouples high-level factory estimators from direct connection details.