### PR TITLE
feat: integrate separated OneDrive/SharePoint storage and Data Security with pagination

### DIFF
--- a/core/graph/reports.py
+++ b/core/graph/reports.py
@@ -132,3 +132,16 @@ class ReportsService:
             ("https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(period='D180')", "M365AppUserDetail_sp_od(180d).csv")
         ]
         self.download_reports_batch(reports, output_dir)
+
+    def download_sharepoint_details(self, output_dir: str) -> None:
+        """Downloads only SharePoint site usage detail report."""
+        self.download_report("https://graph.microsoft.com/v1.0/reports/getSharePointSiteUsageDetail(period='D180')", "SharePointSiteUsageDetail(180d).csv", output_dir)
+
+    def download_onedrive_details(self, output_dir: str) -> None:
+        """Downloads OneDrive usage account, activity, and app user detail reports concurrently."""
+        reports = [
+            ("https://graph.microsoft.com/v1.0/reports/getOneDriveUsageAccountDetail(period='D180')", "OneDriveUsageAccountDetail(180d).csv"),
+            ("https://graph.microsoft.com/v1.0/reports/getOneDriveActivityUserDetail(period='D180')", "OneDriveActivityUserDetail(180d).csv"),
+            ("https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(period='D180')", "M365AppUserDetail_sp_od(180d).csv")
+        ]
+        self.download_reports_batch(reports, output_dir)

--- a/core/graph/security.py
+++ b/core/graph/security.py
@@ -46,3 +46,5 @@ class SecurityService:
                 raise ConnectionError(f"Microsoft Graph API request failed with status {resp.status_code}")
         finally:
             self.client.release_token(token_slot)
+
+

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -28,7 +28,7 @@ usage_logger = logging.getLogger("LicenseUsageAsyncLogger")
 # Import shared styles
 from telemetry.styles import *
 
-def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> list[dict]:
+def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> dict:
     """Pipeline specifically for security and governance policy data collection."""
     usage_logger.info("Starting Data Security & Governance Pipeline...")
     
@@ -43,13 +43,28 @@ def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> lis
     client.authenticate()
     service = SecurityService(client)
     
+    labels = None
+    labels_error = None
+    
+    # Fetch Sensitivity Labels
     try:
         labels = service.fetch_sensitivity_labels()
         # Sort labels by priority descending
         labels.sort(key=lambda x: x.get("priority", 0), reverse=True)
-        return labels
-    finally:
-        client.close()
+    except Exception as e:
+        usage_logger.error("Failed to fetch sensitivity labels", exc_info=True)
+        labels_error = str(e)
+        
+    client.close()
+    
+    if labels_error:
+        raise ConnectionError(f"Security governance fetch failed.\nLabels Error: {labels_error}")
+        
+    return {
+        "labels": labels,
+        "labels_error": labels_error
+    }
+
 
 class DataSecurityGovernanceFrame(ctk.CTkFrame):
     """Self-contained customtkinter component wrapping Data Security & Governance UI."""
@@ -61,16 +76,67 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.on_status_change = status_change_callback
         self.status = None  # 'loading', 'success', 'error', None
         
+        self.flattened_rows = []
+        self.current_page = 0
+        self.ITEMS_PER_PAGE = 8
+        
         self.build_ui()
 
     def build_ui(self):
         """Creates card container for the tab."""
         self.pack(fill="x", expand=True, pady=(20, 10))
         
-        ctk.CTkLabel(self, text="Data Security & Governance (Sensitivity Labels)", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
+        # Permanent section heading visible during loading and error states
+        self.main_title = ctk.CTkLabel(self, text="Data Security & Governance", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN)
+        self.main_title.pack(anchor="w", pady=(0, 10))
         
         self.state_frame = ctk.CTkFrame(self, fg_color="transparent")
-        self.grid_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        # Grid for Sensitivity Labels
+        self.labels_grid = ctk.CTkFrame(
+            self,
+            fg_color=COLOR_SURFACE,
+            border_color=COLOR_OUTLINE_LIGHT,
+            border_width=1,
+            corner_radius=8
+        )
+        
+        # Pagination controls frame (centered below the grid)
+        self.pagination_frame = ctk.CTkFrame(self, fg_color="transparent")
+        
+        self.btn_prev = ctk.CTkButton(
+            self.pagination_frame,
+            text="◀ Prev",
+            command=self._prev_page,
+            width=80,
+            fg_color="transparent",
+            border_width=1,
+            text_color=COLOR_PRIMARY,
+            border_color=COLOR_PRIMARY,
+            hover_color=COLOR_SECONDARY_HOVER
+        )
+        self.btn_prev.pack(side="left", padx=10)
+        
+        self.lbl_page_info = ctk.CTkLabel(
+            self.pagination_frame,
+            text="Page 1 of 1",
+            font=FONT_BODY_MEDIUM,
+            text_color=COLOR_TEXT_MAIN
+        )
+        self.lbl_page_info.pack(side="left", padx=10)
+        
+        self.btn_next = ctk.CTkButton(
+            self.pagination_frame,
+            text="Next ▶",
+            command=self._next_page,
+            width=80,
+            fg_color="transparent",
+            border_width=1,
+            text_color=COLOR_PRIMARY,
+            border_color=COLOR_PRIMARY,
+            hover_color=COLOR_SECONDARY_HOVER
+        )
+        self.btn_next.pack(side="left", padx=10)
         
         self.reset_view()
 
@@ -78,12 +144,16 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         """Resets and hides grids."""
         self.pack_forget()
         self.state_frame.pack_forget()
-        self.grid_frame.pack_forget()
+        self.labels_grid.pack_forget()
+        self.pagination_frame.pack_forget()
         
         for w in self.state_frame.winfo_children():
             w.destroy()
-        for w in self.grid_frame.winfo_children():
+        for w in self.labels_grid.winfo_children():
             w.destroy()
+            
+        self.flattened_rows = []
+        self.current_page = 0
 
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
@@ -94,7 +164,12 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
     def _set_state_error(self, error_msg):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM).pack(pady=(20, 10))
+
+        display_msg = error_msg
+        if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
+            display_msg = "Information Protection permission required.\nPlease grant the 'SensitivityLabels.Read.All' application permission to your App Registration in Microsoft Entra ID."
+
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -109,9 +184,9 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.on_status_change()
         
         self.pack(fill="x", expand=True, pady=(20, 10))
-        self.grid_frame.pack_forget()
+        self.labels_grid.pack_forget()
         
-        self._set_state_loading("Retrieving tenant Sensitivity Labels configuration...")
+        self._set_state_loading("Retrieving tenant Sensitivity Labels...")
         
         threading.Thread(
             target=self._execute_worker,
@@ -129,72 +204,166 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
             usage_logger.error("Exception caught in Data Security & Governance worker.", exc_info=True)
             self.after(0, self._render_error, str(e))
 
-    def _render_success(self, data: list[dict]):
+    def _render_success(self, data: dict):
         self.state_frame.pack_forget()
-        for w in self.grid_frame.winfo_children():
+        for w in self.labels_grid.winfo_children():
             w.destroy()
 
-        if not data:
-            ctk.CTkLabel(self.grid_frame, text="No Sensitivity Labels configured in this tenant.", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB).pack(padx=20, pady=20)
-            self.grid_frame.pack(fill="x", expand=True)
-            self.status = "success"
-            self.on_status_change()
-            return
+        labels = data.get("labels")
+        labels_error = data.get("labels_error")
 
-        self.grid_frame.pack(fill="x", expand=True)
+        self.status = "success"
 
-        # Define column weights for proper proportional spacing
-        self.grid_frame.grid_columnconfigure(0, weight=2)  # Label Name
-        self.grid_frame.grid_columnconfigure(1, weight=3)  # Description
-        self.grid_frame.grid_columnconfigure(2, weight=1)  # Priority
-        self.grid_frame.grid_columnconfigure(3, weight=2)  # Applicable To
-        self.grid_frame.grid_columnconfigure(4, weight=1)  # Status
+        # 1. Render Sensitivity Labels Grid
+        self.labels_grid.pack(fill="x", expand=True, pady=(0, 15))
 
-        headers = ["Sensitivity Label", "Description", "Priority", "Applicable Targets", "Status"]
-        for col_idx, head_text in enumerate(headers):
-            cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
-            cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
-            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+        if labels_error:
+            ctk.CTkLabel(self.labels_grid, text=f"✖ Failed to load Sensitivity Labels: {labels_error}", font=FONT_BODY_MEDIUM, text_color=COLOR_ERROR).pack(padx=20, pady=20)
+            self.pagination_frame.pack_forget()
+        elif labels is None or not labels:
+            ctk.CTkLabel(self.labels_grid, text="No Sensitivity Labels configured in this tenant.", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB).pack(padx=20, pady=20)
+            self.pagination_frame.pack_forget()
+        else:
+            # Define column weights for proper proportional spacing
+            self.labels_grid.grid_columnconfigure(0, weight=2)  # Label Name
+            self.labels_grid.grid_columnconfigure(1, weight=3)  # Description
+            self.labels_grid.grid_columnconfigure(2, weight=1)  # Priority
+            self.labels_grid.grid_columnconfigure(3, weight=2)  # Applicable To
+            self.labels_grid.grid_columnconfigure(4, weight=1)  # Status
 
-        for r_idx, label in enumerate(data, start=1):
+            headers = ["Sensitivity Label", "Description", "Priority", "Applicable Targets", "Status"]
+            for col_idx, head_text in enumerate(headers):
+                cell = ctk.CTkFrame(self.labels_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
+                cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+            # Flatten parent labels and their sorted sublabels
+            self.flattened_rows = []
+            for parent in labels:
+                self.flattened_rows.append({
+                    "name": parent.get("name", "N/A"),
+                    "description": parent.get("description", "") or parent.get("toolTip", "") or "N/A",
+                    "priority": parent.get("priority", 0),
+                    "applicableTo": parent.get("applicableTo", ""),
+                    "isEnabled": parent.get("isEnabled", True),
+                    "is_sublabel": False
+                })
+                
+                sublabels = parent.get("sublabels", [])
+                if sublabels:
+                    # Sort sublabels by priority descending
+                    sublabels_sorted = sorted(sublabels, key=lambda x: x.get("priority", 0), reverse=True)
+                    for sub in sublabels_sorted:
+                        self.flattened_rows.append({
+                            "name": f"    ↳  {sub.get('name', 'N/A')}",
+                            "description": sub.get("description", "") or sub.get("toolTip", "") or "N/A",
+                            "priority": sub.get("priority", 0),
+                            "applicableTo": sub.get("applicableTo", ""),
+                            "isEnabled": sub.get("isEnabled", True),
+                            "is_sublabel": True
+                        })
+
+            self.current_page = 0
+            self._display_current_page()
+
+            if len(self.flattened_rows) > self.ITEMS_PER_PAGE:
+                self.pagination_frame.pack(pady=(5, 10))
+            else:
+                self.pagination_frame.pack_forget()
+
+        self.on_status_change()
+
+    def _display_current_page(self):
+        # Destroy existing data rows (row > 0)
+        for w in self.labels_grid.winfo_children():
+            info = w.grid_info()
+            if "row" in info and int(info["row"]) > 0:
+                w.destroy()
+
+        total_items = len(self.flattened_rows)
+        total_pages = (total_items + self.ITEMS_PER_PAGE - 1) // self.ITEMS_PER_PAGE
+        if total_pages < 1:
+            total_pages = 1
+
+        # Bounds safety check
+        if self.current_page >= total_pages:
+            self.current_page = total_pages - 1
+        if self.current_page < 0:
+            self.current_page = 0
+
+        start_idx = self.current_page * self.ITEMS_PER_PAGE
+        end_idx = min(start_idx + self.ITEMS_PER_PAGE, total_items)
+
+        page_items = self.flattened_rows[start_idx:end_idx]
+
+        for offset, row_item in enumerate(page_items, start=1):
+            r_idx = offset
             bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
             
-            name = label.get("name", "N/A")
-            desc = label.get("description", "") or label.get("toolTip", "") or "N/A"
-            priority = str(label.get("priority", 0))
-            applicable = ", ".join([x.capitalize() for x in label.get("applicableTo", "").split(",") if x.strip()]) or "N/A"
-            status = "🟢 Enabled" if label.get("isEnabled", True) else "🔴 Disabled"
+            name = row_item["name"]
+            desc = row_item["description"]
+            priority = str(row_item["priority"])
+            applicable = ", ".join([x.capitalize() for x in row_item["applicableTo"].split(",") if x.strip()]) or "N/A"
+            status = "🟢 Enabled" if row_item["isEnabled"] else "🔴 Disabled"
+            is_sublabel = row_item["is_sublabel"]
 
-            c0 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            name_color = COLOR_TEXT_MAIN if not is_sublabel else COLOR_TEXT_SUB
+            name_font = FONT_BODY_BOLD if not is_sublabel else FONT_BODY_MEDIUM
+
+            c0 = ctk.CTkFrame(self.labels_grid, fg_color=bg_style, corner_radius=0)
             c0.grid(row=r_idx, column=0, sticky="nsew", padx=1, pady=1)
-            lbl_name = ctk.CTkLabel(c0, text=name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
+            lbl_name = ctk.CTkLabel(c0, text=name, font=name_font, text_color=name_color)
             lbl_name.pack(padx=10, pady=6, anchor="w")
             c0.bind("<Configure>", lambda e, l=lbl_name: l.configure(wraplength=e.width - 20))
 
-            c1 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c1 = ctk.CTkFrame(self.labels_grid, fg_color=bg_style, corner_radius=0)
             c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
             lbl_desc = ctk.CTkLabel(c1, text=desc, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
             lbl_desc.pack(padx=10, pady=6, anchor="w")
             c1.bind("<Configure>", lambda e, l=lbl_desc: l.configure(wraplength=e.width - 20))
 
-            c2 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c2 = ctk.CTkFrame(self.labels_grid, fg_color=bg_style, corner_radius=0)
             c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
             ctk.CTkLabel(c2, text=priority, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
-            c3 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c3 = ctk.CTkFrame(self.labels_grid, fg_color=bg_style, corner_radius=0)
             c3.grid(row=r_idx, column=3, sticky="nsew", padx=1, pady=1)
             lbl_app = ctk.CTkLabel(c3, text=applicable, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
             lbl_app.pack(padx=10, pady=6, anchor="w")
             c3.bind("<Configure>", lambda e, l=lbl_app: l.configure(wraplength=e.width - 20))
 
-            c4 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c4 = ctk.CTkFrame(self.labels_grid, fg_color=bg_style, corner_radius=0)
             c4.grid(row=r_idx, column=4, sticky="nsew", padx=1, pady=1)
             ctk.CTkLabel(c4, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
-        self.status = "success"
-        self.on_status_change()
+        # Update page info label
+        self.lbl_page_info.configure(text=f"Page {self.current_page + 1} of {total_pages}")
+
+        # Update navigation button states
+        if self.current_page <= 0:
+            self.btn_prev.configure(state="disabled", text_color=COLOR_TEXT_SUB, border_color=COLOR_OUTLINE_LIGHT)
+        else:
+            self.btn_prev.configure(state="normal", text_color=COLOR_PRIMARY, border_color=COLOR_PRIMARY)
+
+        if self.current_page >= total_pages - 1:
+            self.btn_next.configure(state="disabled", text_color=COLOR_TEXT_SUB, border_color=COLOR_OUTLINE_LIGHT)
+        else:
+            self.btn_next.configure(state="normal", text_color=COLOR_PRIMARY, border_color=COLOR_PRIMARY)
+
+    def _prev_page(self):
+        if self.current_page > 0:
+            self.current_page -= 1
+            self._display_current_page()
+
+    def _next_page(self):
+        total_items = len(self.flattened_rows)
+        total_pages = (total_items + self.ITEMS_PER_PAGE - 1) // self.ITEMS_PER_PAGE
+        if self.current_page < total_pages - 1:
+            self.current_page += 1
+            self._display_current_page()
 
     def _render_error(self, err_msg):
         self._set_state_error(err_msg)
         self.status = "error"
         self.on_status_change()
+

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 import customtkinter as ctk
 
 from telemetry import active_users_usage as usage
-from telemetry.sharepoint_onedrive_usage import SharePointOneDriveUsageFrame
+from telemetry.sharepoint_onedrive_usage import SharePointUsageFrame, OneDriveUsageFrame
 from telemetry.data_security_governance import DataSecurityGovernanceFrame
 from telemetry.power_automate import PowerAutomateScanner
 
@@ -93,6 +93,8 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.status_o365_trend = None
         self.status_m365 = None
         self.status_pa = None
+        self.status_sharepoint = None
+        self.status_onedrive = None
 
         self.build_ui()
 
@@ -176,8 +178,16 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.m365_state_frame = ctk.CTkFrame(self.m365_section, fg_color="transparent")
         self.m365_grid_frame = ctk.CTkFrame(self.m365_section, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
 
-        # 5. SharePoint & OneDrive Telemetry Section (Modular Integration)
-        self.sp_od_view = SharePointOneDriveUsageFrame(
+        # 5a. SharePoint Telemetry Section (Modular Integration)
+        self.sharepoint_view = SharePointUsageFrame(
+            master=self,
+            log_callback=self.log_msg,
+            credentials_callback=self._get_credentials,
+            status_change_callback=self._check_all_done
+        )
+
+        # 5b. OneDrive Telemetry Section (Modular Integration)
+        self.onedrive_view = OneDriveUsageFrame(
             master=self,
             log_callback=self.log_msg,
             credentials_callback=self._get_credentials,
@@ -219,7 +229,8 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.o365_section.pack_forget()
         self.o365_trend_section.pack_forget()
         self.m365_section.pack_forget()
-        self.sp_od_view.reset_view()
+        self.sharepoint_view.reset_view()
+        self.onedrive_view.reset_view()
         self.security_gov_view.reset_view()
         self.pa_section.pack_forget()
 
@@ -252,7 +263,11 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
 
     def _check_all_done(self):
         """Checks if all sections have resolved (success or error) and updates main UI."""
-        states = [self.status_sku, self.status_o365, self.status_o365_trend, self.status_m365, self.sp_od_view.status, self.security_gov_view.status, self.status_pa]
+        states = [
+            self.status_sku, self.status_o365, self.status_o365_trend, self.status_m365,
+            self.sharepoint_view.status, self.onedrive_view.status, self.security_gov_view.status,
+            self.status_pa
+        ]
 
         if "loading" in states:
             return
@@ -285,7 +300,8 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.retry_o365(clear_log=False)
         self.retry_o365_trend(clear_log=False)
         self.retry_m365(clear_log=False)
-        self.sp_od_view.trigger_fetch(tenant, clients[0], secrets[0])
+        self.sharepoint_view.trigger_fetch(tenant, clients[0], secrets[0])
+        self.onedrive_view.trigger_fetch(tenant, clients[0], secrets[0])
         self.security_gov_view.trigger_fetch(tenant, clients[0], secrets[0])
         self.retry_power_automate(clear_log=False)
 

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Modular SharePoint and OneDrive usage telemetry scanner and visual interface."""
+"""Modular SharePoint and OneDrive usage telemetry scanners and visual interfaces."""
 
 import os
 import csv
@@ -170,15 +170,43 @@ def parse_onenote_users_csv(filepath):
             if row.get("Is Deleted", "").strip().upper() != "TRUE":
                 val = row.get("OneNote", "").strip().lower()
                 if val in ["yes", "true"]:
-                    onenote_users += 1
+                     onenote_users += 1
 
     return {
         "onenote_users": onenote_users
     }
 
-def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
-    """Pipeline specifically for SharePoint and OneDrive telemetry data collection."""
-    usage_logger.info("Starting SharePoint & OneDrive Telemetry Pipeline...")
+# =================================================================================
+# INDEPENDENT SCANNING PIPELINES
+# =================================================================================
+
+def run_sharepoint_pipeline(client_id, client_secret, tenant_id) -> dict:
+    """Pipeline specifically for SharePoint telemetry data collection."""
+    usage_logger.info("Starting SharePoint Telemetry Pipeline...")
+    
+    client = GraphClient(
+        tenant_id=tenant_id,
+        client_ids=client_id,
+        client_secrets=client_secret,
+        concurrency=1,
+        retries=5,
+        backoff=2
+    )
+    client.authenticate()
+    service = ReportsService(client)
+    
+    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
+    reports_dir = os.path.join(script_dir, "reports")
+    
+    service.download_sharepoint_details(reports_dir)
+    client.close()
+    
+    sp_data = parse_sharepoint_csv(os.path.join(reports_dir, "SharePointSiteUsageDetail(180d).csv"))
+    return sp_data
+
+def run_onedrive_pipeline(client_id, client_secret, tenant_id) -> dict:
+    """Pipeline specifically for OneDrive telemetry data collection."""
+    usage_logger.info("Starting OneDrive Telemetry Pipeline...")
     
     client = GraphClient(
         tenant_id=tenant_id,
@@ -194,10 +222,9 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports")
     
-    service.download_sharepoint_onedrive_details(reports_dir)
+    service.download_onedrive_details(reports_dir)
     client.close()
     
-    sp_data = parse_sharepoint_csv(os.path.join(reports_dir, "SharePointSiteUsageDetail(180d).csv"))
     od_data = parse_onedrive_csv(os.path.join(reports_dir, "OneDriveUsageAccountDetail(180d).csv"))
     od_act_data = parse_onedrive_activity_csv(os.path.join(reports_dir, "OneDriveActivityUserDetail(180d).csv"))
     onenote_data = parse_onenote_users_csv(os.path.join(reports_dir, "M365AppUserDetail_sp_od(180d).csv"))
@@ -209,16 +236,14 @@ def run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant_id):
     # Merge OneNote user data
     od_data["onenote_users"] = onenote_data["onenote_users"]
     
-    return {
-        "sharepoint": sp_data,
-        "onedrive": od_data
-    }
+    return od_data
 
 # =================================================================================
-# CUSTOM UI COMPONENT CLASS (Preserved identically for visual parity)
+# MODULAR UI COMPONENTS
 # =================================================================================
-class SharePointOneDriveUsageFrame(ctk.CTkFrame):
-    """Self-contained customtkinter component wrapping SharePoint & OneDrive Telemetry UI."""
+
+class SharePointUsageFrame(ctk.CTkFrame):
+    """Self-contained customtkinter component wrapping SharePoint Telemetry UI."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
         super().__init__(master, fg_color="transparent", **kwargs)
@@ -233,7 +258,7 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
         """Creates card container for the tab."""
         self.pack(fill="x", expand=True, pady=(20, 10))
         
-        ctk.CTkLabel(self, text="SharePoint & OneDrive Telemetry (180 Days)", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
+        ctk.CTkLabel(self, text="SharePoint Site Usage Telemetry (180 Days)", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
         
         self.state_frame = ctk.CTkFrame(self, fg_color="transparent")
         self.grid_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
@@ -260,7 +285,12 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
     def _set_state_error(self, error_msg):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM).pack(pady=(20, 10))
+
+        display_msg = error_msg
+        if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
+            display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Microsoft Entra ID."
+
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -277,7 +307,7 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
         self.pack(fill="x", expand=True, pady=(20, 10))
         self.grid_frame.pack_forget()
         
-        self._set_state_loading("Downloading and parsing SharePoint & OneDrive reports...")
+        self._set_state_loading("Downloading and parsing SharePoint Site Usage reports...")
         
         threading.Thread(
             target=self._execute_worker,
@@ -286,13 +316,13 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
         ).start()
 
     def _execute_worker(self, tenant: str, client_id: str, client_secret: str):
-        usage_logger.info("Executing thread: _execute_sp_od_worker")
+        usage_logger.info("Executing thread: _execute_sharepoint_worker")
         try:
-            data = run_sharepoint_onedrive_pipeline(client_id, client_secret, tenant)
-            usage_logger.info("Successfully completed SharePoint & OneDrive telemetry data fetch.")
+            data = run_sharepoint_pipeline(client_id, client_secret, tenant)
+            usage_logger.info("Successfully completed SharePoint telemetry data fetch.")
             self.after(0, self._render_success, data)
         except Exception as e:
-            usage_logger.error("Exception caught in SharePoint & OneDrive worker.", exc_info=True)
+            usage_logger.error("Exception caught in SharePoint worker.", exc_info=True)
             self.after(0, self._render_error, str(e))
 
     def _render_success(self, data: dict):
@@ -302,35 +332,23 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
 
         self.grid_frame.pack(fill="x", expand=True)
 
-        self.grid_frame.grid_columnconfigure(0, weight=2)
-        self.grid_frame.grid_columnconfigure(1, weight=1)
-        self.grid_frame.grid_columnconfigure(2, weight=1)
+        self.grid_frame.grid_columnconfigure(0, weight=3)
+        self.grid_frame.grid_columnconfigure(1, weight=2)
 
-        headers_sp_od = ["Metric Description", "SharePoint Sites", "OneDrive Accounts"]
-        for col_idx, head_text in enumerate(headers_sp_od):
+        headers_sp = ["SharePoint Metric Description", "Value / Measurement"]
+        for col_idx, head_text in enumerate(headers_sp):
             cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
             cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
             ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
 
-        sp = data.get("sharepoint", {})
-        od = data.get("onedrive", {})
-
         rows_data = [
-            ("Total Count", f"{sp.get('total_sites', 0):,} Sites", f"{od.get('total_accounts', 0):,} Accounts"),
-            ("Total Storage Used", sp.get("total_storage_formatted", "0.00 Bytes"), od.get("total_storage_formatted", "0.00 Bytes")),
-            ("Total File Count", f"{sp.get('total_files', 0):,} Files", f"{od.get('total_files', 0):,} Files"),
-            ("Active File Count", 
-             f"{sp.get('active_files', 0):,} Files ({sp.get('active_files_pct', 0.0):.1f}%)", 
-             f"{od.get('active_files', 0):,} Files ({od.get('active_files_pct', 0.0):.1f}%)"),
-            ("Users with Synced Files", 
-             "N/A", 
-             f"{od.get('sync_users', 0):,} Users ({od.get('sync_users_pct', 0.0):.1f}%)"),
-            ("OneNote Active Users", 
-             "N/A", 
-             f"{od.get('onenote_users', 0):,} Users")
+            ("Total Sites Count", f"{data.get('total_sites', 0):,} Sites"),
+            ("Total Storage Used", data.get("total_storage_formatted", "0.00 Bytes")),
+            ("Total Files Stored", f"{data.get('total_files', 0):,} Files"),
+            ("Active Files Count", f"{data.get('active_files', 0):,} Files ({data.get('active_files_pct', 0.0):.1f}%)")
         ]
 
-        for r_idx, (metric_name, sp_val, od_val) in enumerate(rows_data, start=1):
+        for r_idx, (metric_name, val) in enumerate(rows_data, start=1):
             bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
             
             c0 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
@@ -339,11 +357,135 @@ class SharePointOneDriveUsageFrame(ctk.CTkFrame):
 
             c1 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
             c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
-            ctk.CTkLabel(c1, text=sp_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+            ctk.CTkLabel(c1, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
-            c2 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
-            c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
-            ctk.CTkLabel(c2, text=od_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+        self.status = "success"
+        self.on_status_change()
+
+    def _render_error(self, err_msg):
+        self._set_state_error(err_msg)
+        self.status = "error"
+        self.on_status_change()
+
+
+class OneDriveUsageFrame(ctk.CTkFrame):
+    """Self-contained customtkinter component wrapping OneDrive Telemetry UI."""
+    
+    def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
+        super().__init__(master, fg_color="transparent", **kwargs)
+        self.log_msg = log_callback
+        self.get_credentials = credentials_callback
+        self.on_status_change = status_change_callback
+        self.status = None  # 'loading', 'success', 'error', None
+        
+        self.build_ui()
+
+    def build_ui(self):
+        """Creates card container for the tab."""
+        self.pack(fill="x", expand=True, pady=(20, 10))
+        
+        ctk.CTkLabel(self, text="OneDrive Usage Telemetry (180 Days)", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
+        
+        self.state_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.grid_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        self.reset_view()
+
+    def reset_view(self):
+        """Resets and hides grids."""
+        self.pack_forget()
+        self.state_frame.pack_forget()
+        self.grid_frame.pack_forget()
+        
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+    def _set_state_loading(self, msg="Loading..."):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _set_state_error(self, error_msg):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+
+        display_msg = error_msg
+        if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
+            display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Microsoft Entra ID."
+
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _retry_fetch(self):
+        tenant, clients, secrets = self.get_credentials()
+        if tenant:
+            self.trigger_fetch(tenant, clients[0], secrets[0])
+
+    def trigger_fetch(self, tenant, client_id, client_secret):
+        """Triggers parallel fetches inside isolated background threads."""
+        self.status = "loading"
+        self.on_status_change()
+        
+        self.pack(fill="x", expand=True, pady=(20, 10))
+        self.grid_frame.pack_forget()
+        
+        self._set_state_loading("Downloading and parsing OneDrive reports...")
+        
+        threading.Thread(
+            target=self._execute_worker,
+            args=(tenant, client_id, client_secret),
+            daemon=True
+        ).start()
+
+    def _execute_worker(self, tenant: str, client_id: str, client_secret: str):
+        usage_logger.info("Executing thread: _execute_onedrive_worker")
+        try:
+            data = run_onedrive_pipeline(client_id, client_secret, tenant)
+            usage_logger.info("Successfully completed OneDrive telemetry data fetch.")
+            self.after(0, self._render_success, data)
+        except Exception as e:
+            usage_logger.error("Exception caught in OneDrive worker.", exc_info=True)
+            self.after(0, self._render_error, str(e))
+
+    def _render_success(self, data: dict):
+        self.state_frame.pack_forget()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+        self.grid_frame.pack(fill="x", expand=True)
+
+        self.grid_frame.grid_columnconfigure(0, weight=3)
+        self.grid_frame.grid_columnconfigure(1, weight=2)
+
+        headers_od = ["OneDrive Metric Description", "Value / Measurement"]
+        for col_idx, head_text in enumerate(headers_od):
+            cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
+            cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+        rows_data = [
+            ("Total Accounts Count", f"{data.get('total_accounts', 0):,} Accounts"),
+            ("Total Storage Used", data.get("total_storage_formatted", "0.00 Bytes")),
+            ("Total Files Stored", f"{data.get('total_files', 0):,} Files"),
+            ("Active Files Count", f"{data.get('active_files', 0):,} Files ({data.get('active_files_pct', 0.0):.1f}%)"),
+            ("Users with Synced Files", f"{data.get('sync_users', 0):,} Users ({data.get('sync_users_pct', 0.0):.1f}%)"),
+            ("OneNote Active Users", f"{data.get('onenote_users', 0):,} Users")
+        ]
+
+        for r_idx, (metric_name, val) in enumerate(rows_data, start=1):
+            bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+            
+            c0 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c0.grid(row=r_idx, column=0, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(c0, text=metric_name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+            c1 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(c1, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
         self.status = "success"
         self.on_status_change()


### PR DESCRIPTION
This pull request integrates the clean, restructured OneDrive and SharePoint Storage frames as independent telemetry blocks alongside the tenant-wide Data Security & Governance sensitivity labels grid (complete with hierachical nested sublabels, sorting, and in-memory pagination Prev/Next buttons) and user-friendly Entra ID permission instructions.