### PR TITLE
feat: integrate separated OneDrive/SharePoint storage and Data Security with pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ To run the retention policy discovery features using certificate-based authentic
     ```bash
     brew install powershell
     ```
+    
+    Alternatively, to install PowerShell Core directly via the command line on your Mac, run the following commands in your **Terminal**:
+
+    ##### 1. Download the package using `curl`
+    ```bash
+    curl -L -o /tmp/powershell.pkg https://github.com/PowerShell/PowerShell/releases/download/v7.4.2/powershell-7.4.2-osx-arm64.pkg
+    ```
+
+    ##### 2. Install the package using `installer` (requires your Mac password)
+    ```bash
+    sudo installer -pkg /tmp/powershell.pkg -target /
+    ```
+
+    ##### 3. Install the Exchange Online Module
+    ```bash
+    pwsh -c "Install-Module -Name ExchangeOnlineManagement -Scope CurrentUser -Force"
+    ```
+
+    Once completed, you can run the Migration Planner tool (`python3 migration_planner.py`) and initiate a clean telemetry run.
+
 *   **Windows**: Install via winget:
     ```cmd
     winget install --id Microsoft.Powershell --source winget

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ If your organization restricts installing packages globally, use a virtual envir
     *   Mac/Linux: `source venv/bin/activate`
 3.  **Install packages** as shown above inside this environment.
 
+### 4. PowerShell Prerequisites (for Retention Policy Scanning)
+
+To run the retention policy discovery features using certificate-based authentication, the following must be installed on your system:
+
+#### Install PowerShell Core (`pwsh`)
+*   **macOS**: Install via Homebrew:
+    ```bash
+    brew install powershell
+    ```
+*   **Windows**: Install via winget:
+    ```cmd
+    winget install --id Microsoft.Powershell --source winget
+    ```
+
+#### Install ExchangeOnlineManagement Module
+Open PowerShell (`pwsh`) and install the Microsoft Exchange Online module:
+```powershell
+Install-Module -Name ExchangeOnlineManagement -Scope CurrentUser -Force
+```
+
 ---
 
 ## Setting up Microsoft Azure

--- a/core/graph/directory.py
+++ b/core/graph/directory.py
@@ -43,3 +43,42 @@ class DirectoryService:
             return resp.json()
         finally:
             self.client.release_token(token_slot)
+
+    def get_tenant_primary_domain(self) -> str:
+        """Queries the /organization endpoint to retrieve the tenant's default or initial domain name."""
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}"
+        }
+        try:
+            url = "https://graph.microsoft.com/v1.0/organization"
+            logger.info("Querying Graph API organization endpoint: %s", url)
+            resp = session.get(url, headers=headers, timeout=30.0)
+            resp.raise_for_status()
+            data = resp.json()
+            values = data.get("value", [])
+            if not values:
+                raise ValueError("No organization details found in Microsoft Graph.")
+            
+            domains = values[0].get("verifiedDomains", [])
+            
+            # 1. Find default domain
+            for d in domains:
+                if d.get("isDefault"):
+                    return d.get("name")
+                    
+            # 2. Fallback to initial domain (.onmicrosoft.com)
+            for d in domains:
+                if d.get("isInitial"):
+                    return d.get("name")
+            
+            # 3. Fallback to first verified domain
+            if domains:
+                return domains[0].get("name")
+                
+            raise ValueError("No verified domains found in organization details.")
+        finally:
+            self.client.release_token(token_slot)
+

--- a/core/powershell/__init__.py
+++ b/core/powershell/__init__.py
@@ -1,0 +1,1 @@
+# Init powershell core package

--- a/core/powershell/client.py
+++ b/core/powershell/client.py
@@ -5,9 +5,10 @@ import logging
 logger = logging.getLogger("PowerShellClient")
 
 class PowerShellClient:
-    def __init__(self, tenant_id, client_id, cert_dir="/Users/srishtinegi/Desktop/Test/certificates"):
+    def __init__(self, tenant_id, client_id, cert_password="YourSecureCertPassword123", cert_dir="/Users/srishtinegi/Desktop/Test/certificates"):
         self.tenant_id = tenant_id
         self.client_id = client_id
+        self.cert_password = cert_password
         self.cert_dir = cert_dir
 
     def locate_certificate(self) -> str:

--- a/core/powershell/client.py
+++ b/core/powershell/client.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import logging
+
+logger = logging.getLogger("PowerShellClient")
+
+class PowerShellClient:
+    def __init__(self, tenant_id, client_id, cert_dir="/Users/srishtinegi/Desktop/Test/certificates"):
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.cert_dir = cert_dir
+
+    def locate_certificate(self) -> str:
+        """Finds the first .pfx or .pem certificate in the target directory."""
+        if not os.path.exists(self.cert_dir):
+            raise FileNotFoundError(f"Certificate directory does not exist: {self.cert_dir}")
+        
+        for file in os.listdir(self.cert_dir):
+            if file.endswith(".pfx") or file.endswith(".pem"):
+                return os.path.join(self.cert_dir, file)
+                
+        raise FileNotFoundError(f"No .pfx or .pem certificate found in {self.cert_dir}")
+
+    def execute_script(self, script_relative_path: str, args: list) -> str:
+        """Executes pwsh with the specified script and arguments."""
+        script_path = os.path.join(os.path.dirname(__file__), script_relative_path)
+        
+        if not os.path.exists(script_path):
+            raise FileNotFoundError(f"PowerShell script not found at {script_path}")
+            
+        # Construct CLI command
+        command = ["pwsh", "-NoProfile", "-NonInteractive", "-File", script_path] + args
+        
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            logger.error(f"PowerShell script failed: {e.stderr}")
+            raise RuntimeError(f"PowerShell script execution failed: {e.stderr or e.stdout}")
+        except FileNotFoundError:
+            raise RuntimeError("PowerShell core ('pwsh') is not installed or not in PATH. Please install it (e.g. 'brew install powershell' on macOS).")

--- a/core/powershell/client.py
+++ b/core/powershell/client.py
@@ -5,22 +5,18 @@ import logging
 logger = logging.getLogger("PowerShellClient")
 
 class PowerShellClient:
-    def __init__(self, tenant_id, client_id, cert_password="YourSecureCertPassword123", cert_dir="/Users/srishtinegi/Desktop/Test/certificates"):
+    def __init__(self, tenant_id, client_id, client_secret):
         self.tenant_id = tenant_id
         self.client_id = client_id
-        self.cert_password = cert_password
-        self.cert_dir = cert_dir
+        self.cert_password = client_secret
 
     def locate_certificate(self) -> str:
-        """Finds the first .pfx or .pem certificate in the target directory."""
-        if not os.path.exists(self.cert_dir):
-            raise FileNotFoundError(f"Certificate directory does not exist: {self.cert_dir}")
-        
-        for file in os.listdir(self.cert_dir):
-            if file.endswith(".pfx") or file.endswith(".pem"):
-                return os.path.join(self.cert_dir, file)
-                
-        raise FileNotFoundError(f"No .pfx or .pem certificate found in {self.cert_dir}")
+        """Locates the automated hybrid auth PFX certificate path."""
+        from core.cert_auth import get_cert_paths
+        _, _, pfx_path = get_cert_paths()
+        if not os.path.exists(pfx_path):
+            raise FileNotFoundError(f"Hybrid auth PFX certificate not found at {pfx_path}. Please complete the hybrid authentication flow on the login page first.")
+        return pfx_path
 
     def execute_script(self, script_relative_path: str, args: list) -> str:
         """Executes pwsh with the specified script and arguments."""

--- a/core/powershell/retention.py
+++ b/core/powershell/retention.py
@@ -17,6 +17,8 @@ class RetentionService:
             "-Organization", self.client.tenant_id,
             "-CertificatePath", cert_path
         ]
+        if self.client.cert_password:
+            args += ["-CertificatePassword", self.client.cert_password]
 
         raw_output = self.client.execute_script("scripts/get_retention_policies.ps1", args)
         

--- a/core/powershell/retention.py
+++ b/core/powershell/retention.py
@@ -1,0 +1,37 @@
+import json
+from core.powershell.client import PowerShellClient
+
+class RetentionService:
+    def __init__(self, client: PowerShellClient):
+        self.client = client
+
+    def fetch_retention_policies(self) -> list:
+        """Locates certificate, triggers powershell execution, and parses retention policies."""
+        try:
+            cert_path = self.client.locate_certificate()
+        except Exception as e:
+            raise RuntimeError(f"Failed to locate certificate for authentication: {str(e)}")
+
+        args = [
+            "-AppId", self.client.client_id,
+            "-Organization", self.client.tenant_id,
+            "-CertificatePath", cert_path
+        ]
+
+        raw_output = self.client.execute_script("scripts/get_retention_policies.ps1", args)
+        
+        if not raw_output or not raw_output.strip():
+            return []
+
+        try:
+            return json.loads(raw_output)
+        except json.JSONDecodeError:
+            # Parse JSON block in case of warning/header lines outputted by powershell environment
+            lines = raw_output.strip().split('\n')
+            json_str = ""
+            for line in lines:
+                if line.startswith("[") or line.startswith("{") or json_str:
+                    json_str += line
+            if json_str:
+                return json.loads(json_str)
+            raise RuntimeError(f"PowerShell returned non-JSON format: {raw_output}")

--- a/core/powershell/scripts/get_retention_policies.ps1
+++ b/core/powershell/scripts/get_retention_policies.ps1
@@ -27,10 +27,43 @@ if ($CertificatePassword) {
 }
 
 try {
-    # Retrieve policies and convert to JSON
+    # Retrieve policies
     $policies = Get-RetentionCompliancePolicy
+    $output = @()
+
     if ($policies) {
-        $policies | ConvertTo-Json -Depth 5
+        # Handle case where $policies is not an array
+        $policies_list = @($policies)
+        
+        foreach ($policy in $policies_list) {
+            # Get the rules associated with this policy
+            $rules = Get-RetentionComplianceRule -Policy $policy.Name
+            
+            $duration = "N/A"
+            $action = "N/A"
+            if ($rules) {
+                $rules_list = @($rules)
+                if ($rules_list.Count -gt 0) {
+                    $rule = $rules_list[0]
+                    $duration = $rule.RetentionDuration
+                    $action = $rule.RetentionAction
+                }
+            }
+            
+            # Construct a combined custom object
+            $policyObj = [PSCustomObject]@{
+                Name = $policy.Name
+                Comment = $policy.Comment
+                Workload = $policy.Workload
+                Mode = $policy.Mode
+                DistributionStatus = $policy.DistributionStatus
+                Enabled = $policy.Enabled
+                Duration = $duration
+                RetentionAction = $action
+            }
+            $output += $policyObj
+        }
+        $output | ConvertTo-Json -Depth 5
     } else {
         "[]"
     }

--- a/core/powershell/scripts/get_retention_policies.ps1
+++ b/core/powershell/scripts/get_retention_policies.ps1
@@ -4,7 +4,9 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Organization,
     [Parameter(Mandatory=$true)]
-    [string]$CertificatePath
+    [string]$CertificatePath,
+    [Parameter(Mandatory=$false)]
+    [string]$CertificatePassword
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,7 +19,12 @@ if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
 Import-Module ExchangeOnlineManagement
 
 # Connect to Security & Compliance PowerShell using App-Only Cert Auth
-Connect-IPPSSession -CertificateFilePath $CertificatePath -AppId $AppId -Organization $Organization
+if ($CertificatePassword) {
+    $secPassword = ConvertTo-SecureString -String $CertificatePassword -AsPlainText -Force
+    Connect-IPPSSession -CertificateFilePath $CertificatePath -CertificatePassword $secPassword -AppId $AppId -Organization $Organization
+} else {
+    Connect-IPPSSession -CertificateFilePath $CertificatePath -AppId $AppId -Organization $Organization
+}
 
 try {
     # Retrieve policies and convert to JSON

--- a/core/powershell/scripts/get_retention_policies.ps1
+++ b/core/powershell/scripts/get_retention_policies.ps1
@@ -1,0 +1,33 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$AppId,
+    [Parameter(Mandatory=$true)]
+    [string]$Organization,
+    [Parameter(Mandatory=$true)]
+    [string]$CertificatePath
+)
+
+$ErrorActionPreference = "Stop"
+
+# Check if ExchangeOnlineManagement module is installed beforehand
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+    throw "ExchangeOnlineManagement PowerShell module is not installed. Please install it beforehand by running: Install-Module -Name ExchangeOnlineManagement -Scope CurrentUser"
+}
+
+Import-Module ExchangeOnlineManagement
+
+# Connect to Security & Compliance PowerShell using App-Only Cert Auth
+Connect-IPPSSession -CertificateFilePath $CertificatePath -AppId $AppId -Organization $Organization
+
+try {
+    # Retrieve policies and convert to JSON
+    $policies = Get-RetentionCompliancePolicy
+    if ($policies) {
+        $policies | ConvertTo-Json -Depth 5
+    } else {
+        "[]"
+    }
+}
+finally {
+    Disconnect-ExchangeOnline -Confirm:$false
+}

--- a/core/powershell/scripts/get_retention_policies.ps1
+++ b/core/powershell/scripts/get_retention_policies.ps1
@@ -41,12 +41,14 @@ try {
             
             $duration = "N/A"
             $action = "N/A"
+            $trigger = "N/A"
             if ($rules) {
                 $rules_list = @($rules)
                 if ($rules_list.Count -gt 0) {
                     $rule = $rules_list[0]
                     $duration = $rule.RetentionDuration
                     $action = $rule.RetentionAction
+                    $trigger = $rule.RetentionTrigger
                 }
             }
             
@@ -60,6 +62,7 @@ try {
                 Enabled = $policy.Enabled
                 Duration = $duration
                 RetentionAction = $action
+                RetentionTrigger = $trigger
             }
             $output += $policyObj
         }

--- a/migration_planner_telemetry.py
+++ b/migration_planner_telemetry.py
@@ -257,6 +257,7 @@ class ReportsPage(ctk.CTkFrame):
             backoff_var=backoff_var
         )
         self.license_usage_view.pack(fill="both", expand=True)  # CITATION: self.license_usage_view.pack(fill="both", expand=True, padx=15, pady=15)
+        self.license_usage_view.on_all_done_callback = self.on_telemetry_fetch_completed
 
         # Adapt layout recursively to hide original inputs from view
         self.adapt_embedded_view()
@@ -297,6 +298,10 @@ class ReportsPage(ctk.CTkFrame):
             self.embedded_submit_btn.pack_forget()
             self.embedded_submit_btn.grid_forget()
 
+        if hasattr(self.license_usage_view, "inputs_frame"):
+            self.license_usage_view.inputs_frame.pack_forget()
+            self.license_usage_view.inputs_frame.grid_forget()
+
     def on_fetch_report_clicked(self):
         """Stage 2: Migrates stored variables into the hidden entries and clicks the submit thread."""
         tenant = self.controller.stored_tenant
@@ -323,6 +328,10 @@ class ReportsPage(ctk.CTkFrame):
         # Programmatically trigger the hidden connection submit button
         if self.embedded_submit_btn:
             self.embedded_submit_btn.invoke()
+
+    def on_telemetry_fetch_completed(self, success: bool):
+        """Callback from LicenseUsageTab when all parallel reports complete."""
+        self.fetch_btn.configure(state="normal", text="Fetch Report", fg_color="#1E3A8A")
 
     def clear_session_data(self):
         """Wipes the cached parameters from telemetry objects and resets the Fetch button."""

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -55,6 +55,16 @@ def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> dic
         usage_logger.error("Failed to fetch sensitivity labels", exc_info=True)
         labels_error = str(e)
         
+    # Fetch tenant primary domain name from organization endpoint
+    tenant_domain = tenant_id
+    try:
+        from core.graph.directory import DirectoryService
+        dir_svc = DirectoryService(client)
+        tenant_domain = dir_svc.get_tenant_primary_domain()
+        usage_logger.info(f"Retrieved primary tenant domain for Connect-IPPSSession: {tenant_domain}")
+    except Exception as e:
+        usage_logger.warning(f"Could not retrieve tenant domain via Graph. Falling back to Tenant ID Guid: {e}")
+
     client.close()
     
     # Fetch Retention Policies via PowerShell client
@@ -64,7 +74,7 @@ def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> dic
         from core.powershell.client import PowerShellClient
         from core.powershell.retention import RetentionService
         
-        ps_client = PowerShellClient(tenant_id=tenant_id, client_id=client_id)
+        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id)
         retention_service = RetentionService(ps_client)
         policies = retention_service.fetch_retention_policies()
     except Exception as e:

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -75,7 +75,7 @@ def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> dic
         from core.powershell.client import PowerShellClient
         from core.powershell.retention import RetentionService
         
-        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id)
+        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id, client_secret=client_secret)
         retention_service = RetentionService(ps_client)
         policies = retention_service.fetch_retention_policies()
     except Exception as e:

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -57,12 +57,29 @@ def run_security_governance_pipeline(client_id, client_secret, tenant_id) -> dic
         
     client.close()
     
-    if labels_error:
-        raise ConnectionError(f"Security governance fetch failed.\nLabels Error: {labels_error}")
+    # Fetch Retention Policies via PowerShell client
+    policies = None
+    policies_error = None
+    try:
+        from core.powershell.client import PowerShellClient
+        from core.powershell.retention import RetentionService
+        
+        ps_client = PowerShellClient(tenant_id=tenant_id, client_id=client_id)
+        retention_service = RetentionService(ps_client)
+        policies = retention_service.fetch_retention_policies()
+    except Exception as e:
+        usage_logger.error("Failed to fetch retention policies via PowerShell", exc_info=True)
+        policies_error = str(e)
+        
+    # Raise ConnectionError only if BOTH failed
+    if labels_error and policies_error:
+        raise ConnectionError(f"Security governance fetch failed.\nLabels Error: {labels_error}\nPolicies Error: {policies_error}")
         
     return {
         "labels": labels,
-        "labels_error": labels_error
+        "labels_error": labels_error,
+        "policies": policies,
+        "policies_error": policies_error
     }
 
 
@@ -138,6 +155,16 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         )
         self.btn_next.pack(side="left", padx=10)
         
+        # Retention Policies section
+        self.retention_title = ctk.CTkLabel(self, text="Retention Compliance Policies", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN)
+        self.retention_grid = ctk.CTkFrame(
+            self,
+            fg_color=COLOR_SURFACE,
+            border_color=COLOR_OUTLINE_LIGHT,
+            border_width=1,
+            corner_radius=8
+        )
+        
         self.reset_view()
 
     def reset_view(self):
@@ -146,10 +173,14 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.state_frame.pack_forget()
         self.labels_grid.pack_forget()
         self.pagination_frame.pack_forget()
+        self.retention_title.pack_forget()
+        self.retention_grid.pack_forget()
         
         for w in self.state_frame.winfo_children():
             w.destroy()
         for w in self.labels_grid.winfo_children():
+            w.destroy()
+        for w in self.retention_grid.winfo_children():
             w.destroy()
             
         self.flattened_rows = []
@@ -185,8 +216,10 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         
         self.pack(fill="x", expand=True, pady=(20, 10))
         self.labels_grid.pack_forget()
+        self.retention_title.pack_forget()
+        self.retention_grid.pack_forget()
         
-        self._set_state_loading("Retrieving tenant Sensitivity Labels...")
+        self._set_state_loading("Retrieving tenant Security & Compliance policies...")
         
         threading.Thread(
             target=self._execute_worker,
@@ -208,9 +241,13 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.state_frame.pack_forget()
         for w in self.labels_grid.winfo_children():
             w.destroy()
+        for w in self.retention_grid.winfo_children():
+            w.destroy()
 
         labels = data.get("labels")
         labels_error = data.get("labels_error")
+        policies = data.get("policies")
+        policies_error = data.get("policies_error")
 
         self.status = "success"
 
@@ -270,6 +307,11 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 self.pagination_frame.pack(pady=(5, 10))
             else:
                 self.pagination_frame.pack_forget()
+
+        # 2. Render Retention Policies Grid
+        self.retention_title.pack(anchor="w", pady=(20, 10))
+        self.retention_grid.pack(fill="x", expand=True, pady=(0, 15))
+        self._render_retention_policies(policies, policies_error)
 
         self.on_status_change()
 
@@ -366,4 +408,74 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self._set_state_error(err_msg)
         self.status = "error"
         self.on_status_change()
+
+    def _render_retention_policies(self, policies, policies_error):
+        if policies_error:
+            msg = policies_error
+            # Provide helpful, friendly advice if pwsh or dependency issue
+            if "powershell" in policies_error.lower() or "pwsh" in policies_error.lower():
+                msg = "PowerShell Core ('pwsh') is not installed or configured on this machine.\nPlease refer to the Prerequisites in the README to configure it."
+            elif "exchangeonlinemanagement" in policies_error.lower():
+                msg = "ExchangeOnlineManagement PowerShell module is missing.\nPlease run: Install-Module -Name ExchangeOnlineManagement -Scope CurrentUser"
+                
+            ctk.CTkLabel(
+                self.retention_grid, 
+                text=f"✖ {msg}", 
+                font=FONT_BODY_MEDIUM, 
+                text_color=COLOR_ERROR,
+                justify="center"
+            ).pack(padx=20, pady=20)
+        elif policies is None or not policies:
+            ctk.CTkLabel(
+                self.retention_grid, 
+                text="No Retention Compliance Policies found in this tenant.", 
+                font=FONT_BODY_MEDIUM, 
+                text_color=COLOR_TEXT_SUB
+            ).pack(padx=20, pady=20)
+        else:
+            # Configure grid columns
+            self.retention_grid.grid_columnconfigure(0, weight=3)  # Policy Name
+            self.retention_grid.grid_columnconfigure(1, weight=3)  # Applicable Workloads
+            self.retention_grid.grid_columnconfigure(2, weight=1)  # Status
+
+            headers = ["Policy Name", "Applicable Workloads", "Status"]
+            for col_idx, head_text in enumerate(headers):
+                cell = ctk.CTkFrame(self.retention_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
+                cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+            # Handle case where policies is a single dict rather than a list
+            policies_list = policies if isinstance(policies, list) else [policies]
+
+            for r_idx, policy in enumerate(policies_list, start=1):
+                bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+
+                name = policy.get("Name", "N/A")
+                workload = policy.get("Workload", "N/A")
+                
+                # Enabled can be boolean or string
+                enabled_val = policy.get("Enabled", True)
+                if isinstance(enabled_val, str):
+                    is_enabled = enabled_val.lower() == "true"
+                else:
+                    is_enabled = bool(enabled_val)
+                    
+                status = "🟢 Enabled" if is_enabled else "🔴 Disabled"
+
+                c0 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c0.grid(row=r_idx, column=0, sticky="nsew", padx=1, pady=1)
+                lbl_name = ctk.CTkLabel(c0, text=name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
+                lbl_name.pack(padx=10, pady=6, anchor="w")
+                c0.bind("<Configure>", lambda e, l=lbl_name: l.configure(wraplength=e.width - 20))
+
+                c1 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
+                lbl_workload = ctk.CTkLabel(c1, text=workload, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
+                lbl_workload.pack(padx=10, pady=6, anchor="w")
+                c1.bind("<Configure>", lambda e, l=lbl_workload: l.configure(wraplength=e.width - 20))
+
+                c2 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(c2, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
 

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -467,12 +467,11 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
             self.retention_grid.grid_columnconfigure(0, weight=3)  # Policy Name
             self.retention_grid.grid_columnconfigure(1, weight=3)  # Workloads
             self.retention_grid.grid_columnconfigure(2, weight=2)  # Duration & Trigger
-            self.retention_grid.grid_columnconfigure(3, weight=2)  # Action
-            self.retention_grid.grid_columnconfigure(4, weight=1)  # Mode
-            self.retention_grid.grid_columnconfigure(5, weight=1)  # Distribution
-            self.retention_grid.grid_columnconfigure(6, weight=1)  # Status
+            self.retention_grid.grid_columnconfigure(3, weight=1)  # Mode
+            self.retention_grid.grid_columnconfigure(4, weight=1)  # Distribution
+            self.retention_grid.grid_columnconfigure(5, weight=1)  # Status
 
-            headers = ["Policy Name", "Workloads", "Duration", "Action", "Mode", "Distribution", "Status"]
+            headers = ["Policy Name", "Workloads", "Duration", "Mode", "Distribution", "Status"]
             for col_idx, head_text in enumerate(headers):
                 cell = ctk.CTkFrame(self.retention_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
                 cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
@@ -489,7 +488,6 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 workload = policy.get("Workload", "N/A")
                 duration_val = str(policy.get("Duration", "N/A"))
                 trigger_val = policy.get("RetentionTrigger", "N/A")
-                action_val = policy.get("RetentionAction", "N/A")
                 mode = policy.get("Mode", "Enforce")
                 dist_status = policy.get("DistributionStatus", "Success")
                 
@@ -517,14 +515,6 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                     }
                     friendly_trigger = trigger_map.get(trigger_val, trigger_val)
                     duration_str += f"\n(from {friendly_trigger})"
-
-                # Format Action nicely
-                action_map = {
-                    "Keep": "Retain Only",
-                    "KeepAndDelete": "Retain & Delete",
-                    "Delete": "Delete Only"
-                }
-                action_str = action_map.get(action_val, action_val)
 
                 # Enabled can be boolean or string
                 enabled_val = policy.get("Enabled", True)
@@ -563,20 +553,14 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
 
                 c3 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c3.grid(row=r_idx, column=3, sticky="nsew", padx=1, pady=1)
-                lbl_action = ctk.CTkLabel(c3, text=action_str, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
-                lbl_action.pack(padx=10, pady=6, anchor="w")
-                c3.bind("<Configure>", lambda e, l=lbl_action: l.configure(wraplength=e.width - 20))
+                ctk.CTkLabel(c3, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
                 c4 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c4.grid(row=r_idx, column=4, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c4, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c4, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
                 c5 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c5.grid(row=r_idx, column=5, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c5, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
-
-                c6 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
-                c6.grid(row=r_idx, column=6, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c6, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c5, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
 

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -446,11 +446,12 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
             # Configure grid columns
             self.retention_grid.grid_columnconfigure(0, weight=3)  # Policy Name
             self.retention_grid.grid_columnconfigure(1, weight=3)  # Workloads
-            self.retention_grid.grid_columnconfigure(2, weight=1)  # Mode
-            self.retention_grid.grid_columnconfigure(3, weight=1)  # Distribution
-            self.retention_grid.grid_columnconfigure(4, weight=1)  # Status
+            self.retention_grid.grid_columnconfigure(2, weight=2)  # Duration
+            self.retention_grid.grid_columnconfigure(3, weight=1)  # Mode
+            self.retention_grid.grid_columnconfigure(4, weight=1)  # Distribution
+            self.retention_grid.grid_columnconfigure(5, weight=1)  # Status
 
-            headers = ["Policy Name", "Workloads", "Mode", "Distribution", "Status"]
+            headers = ["Policy Name", "Workloads", "Duration", "Mode", "Distribution", "Status"]
             for col_idx, head_text in enumerate(headers):
                 cell = ctk.CTkFrame(self.retention_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
                 cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
@@ -465,9 +466,25 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 name = policy.get("Name", "N/A")
                 comment = policy.get("Comment", "")
                 workload = policy.get("Workload", "N/A")
+                duration_val = str(policy.get("Duration", "N/A"))
                 mode = policy.get("Mode", "Enforce")
                 dist_status = policy.get("DistributionStatus", "Success")
                 
+                # Format Duration nicely
+                duration_str = duration_val
+                if duration_val.lower() == "unlimited":
+                    duration_str = "Keep Forever (Unlimited)"
+                elif duration_val.isdigit():
+                    days = int(duration_val)
+                    if days >= 365:
+                        years = days / 365.0
+                        if years.is_integer():
+                            duration_str = f"{int(years)} Years ({days} days)"
+                        else:
+                            duration_str = f"{years:.1f} Years ({days} days)"
+                    else:
+                        duration_str = f"{days} days"
+
                 # Enabled can be boolean or string
                 enabled_val = policy.get("Enabled", True)
                 if isinstance(enabled_val, str):
@@ -499,14 +516,20 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
 
                 c2 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c2, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                lbl_duration = ctk.CTkLabel(c2, text=duration_str, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
+                lbl_duration.pack(padx=10, pady=6, anchor="w")
+                c2.bind("<Configure>", lambda e, l=lbl_duration: l.configure(wraplength=e.width - 20))
 
                 c3 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c3.grid(row=r_idx, column=3, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c3, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c3, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
                 c4 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c4.grid(row=r_idx, column=4, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c4, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c4, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+                c5 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c5.grid(row=r_idx, column=5, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(c5, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
 

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -18,6 +18,7 @@ import os
 import logging
 import threading
 import customtkinter as ctk
+import webbrowser
 
 from core.graph.client import GraphClient
 from core.graph.security import SecurityService
@@ -166,7 +167,26 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.btn_next.pack(side="left", padx=10)
         
         # Retention Policies section
-        self.retention_title = ctk.CTkLabel(self, text="Retention Compliance Policies", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN)
+        self.retention_header_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.retention_title = ctk.CTkLabel(
+            self.retention_header_frame,
+            text="Retention Compliance Policies",
+            font=FONT_HEADER_SMALL,
+            text_color=COLOR_TEXT_MAIN
+        )
+        self.retention_title.pack(side="left", anchor="w")
+        
+        self.retention_link = ctk.CTkLabel(
+            self.retention_header_frame,
+            text="Open Microsoft Purview Portal ↗",
+            font=FONT_BODY_BOLD,
+            text_color=COLOR_PRIMARY,
+            cursor="hand2"
+        )
+        self.retention_link.pack(side="right", anchor="e", padx=(10, 0))
+        self.retention_link.bind("<Button-1>", lambda e: webbrowser.open("https://purview.microsoft.com/datalifecyclemanagement/retention"))
+        self.retention_link.bind("<Enter>", lambda e: self.retention_link.configure(text_color=COLOR_PRIMARY_HOVER))
+        self.retention_link.bind("<Leave>", lambda e: self.retention_link.configure(text_color=COLOR_PRIMARY))
         self.retention_grid = ctk.CTkFrame(
             self,
             fg_color=COLOR_SURFACE,
@@ -183,7 +203,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.state_frame.pack_forget()
         self.labels_grid.pack_forget()
         self.pagination_frame.pack_forget()
-        self.retention_title.pack_forget()
+        self.retention_header_frame.pack_forget()
         self.retention_grid.pack_forget()
         
         for w in self.state_frame.winfo_children():
@@ -226,7 +246,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         
         self.pack(fill="x", expand=True, pady=(20, 10))
         self.labels_grid.pack_forget()
-        self.retention_title.pack_forget()
+        self.retention_header_frame.pack_forget()
         self.retention_grid.pack_forget()
         
         self._set_state_loading("Retrieving tenant Security & Compliance policies...")
@@ -319,7 +339,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 self.pagination_frame.pack_forget()
 
         # 2. Render Retention Policies Grid
-        self.retention_title.pack(anchor="w", pady=(20, 10))
+        self.retention_header_frame.pack(fill="x", pady=(20, 10))
         self.retention_grid.pack(fill="x", expand=True, pady=(0, 15))
         self._render_retention_policies(policies, policies_error)
 
@@ -446,12 +466,13 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
             # Configure grid columns
             self.retention_grid.grid_columnconfigure(0, weight=3)  # Policy Name
             self.retention_grid.grid_columnconfigure(1, weight=3)  # Workloads
-            self.retention_grid.grid_columnconfigure(2, weight=2)  # Duration
-            self.retention_grid.grid_columnconfigure(3, weight=1)  # Mode
-            self.retention_grid.grid_columnconfigure(4, weight=1)  # Distribution
-            self.retention_grid.grid_columnconfigure(5, weight=1)  # Status
+            self.retention_grid.grid_columnconfigure(2, weight=2)  # Duration & Trigger
+            self.retention_grid.grid_columnconfigure(3, weight=2)  # Action
+            self.retention_grid.grid_columnconfigure(4, weight=1)  # Mode
+            self.retention_grid.grid_columnconfigure(5, weight=1)  # Distribution
+            self.retention_grid.grid_columnconfigure(6, weight=1)  # Status
 
-            headers = ["Policy Name", "Workloads", "Duration", "Mode", "Distribution", "Status"]
+            headers = ["Policy Name", "Workloads", "Duration", "Action", "Mode", "Distribution", "Status"]
             for col_idx, head_text in enumerate(headers):
                 cell = ctk.CTkFrame(self.retention_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
                 cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
@@ -467,13 +488,15 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 comment = policy.get("Comment", "")
                 workload = policy.get("Workload", "N/A")
                 duration_val = str(policy.get("Duration", "N/A"))
+                trigger_val = policy.get("RetentionTrigger", "N/A")
+                action_val = policy.get("RetentionAction", "N/A")
                 mode = policy.get("Mode", "Enforce")
                 dist_status = policy.get("DistributionStatus", "Success")
                 
                 # Format Duration nicely
                 duration_str = duration_val
                 if duration_val.lower() == "unlimited":
-                    duration_str = "Keep Forever (Unlimited)"
+                    duration_str = "Keep Forever"
                 elif duration_val.isdigit():
                     days = int(duration_val)
                     if days >= 365:
@@ -484,6 +507,24 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                             duration_str = f"{years:.1f} Years ({days} days)"
                     else:
                         duration_str = f"{days} days"
+                
+                # Append trigger details to duration string if present and not N/A
+                if trigger_val and trigger_val != "N/A":
+                    trigger_map = {
+                        "DateCreated": "created date",
+                        "DateModified": "last modified date",
+                        "DateLabeled": "labeled date"
+                    }
+                    friendly_trigger = trigger_map.get(trigger_val, trigger_val)
+                    duration_str += f"\n(from {friendly_trigger})"
+
+                # Format Action nicely
+                action_map = {
+                    "Keep": "Retain Only",
+                    "KeepAndDelete": "Retain & Delete",
+                    "Delete": "Delete Only"
+                }
+                action_str = action_map.get(action_val, action_val)
 
                 # Enabled can be boolean or string
                 enabled_val = policy.get("Enabled", True)
@@ -516,20 +557,26 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
 
                 c2 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
-                lbl_duration = ctk.CTkLabel(c2, text=duration_str, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
+                lbl_duration = ctk.CTkLabel(c2, text=duration_str, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left")
                 lbl_duration.pack(padx=10, pady=6, anchor="w")
                 c2.bind("<Configure>", lambda e, l=lbl_duration: l.configure(wraplength=e.width - 20))
 
                 c3 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c3.grid(row=r_idx, column=3, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c3, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                lbl_action = ctk.CTkLabel(c3, text=action_str, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN)
+                lbl_action.pack(padx=10, pady=6, anchor="w")
+                c3.bind("<Configure>", lambda e, l=lbl_action: l.configure(wraplength=e.width - 20))
 
                 c4 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c4.grid(row=r_idx, column=4, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c4, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c4, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
                 c5 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c5.grid(row=r_idx, column=5, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c5, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c5, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+                c6 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c6.grid(row=r_idx, column=6, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(c6, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
 

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -445,10 +445,12 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         else:
             # Configure grid columns
             self.retention_grid.grid_columnconfigure(0, weight=3)  # Policy Name
-            self.retention_grid.grid_columnconfigure(1, weight=3)  # Applicable Workloads
-            self.retention_grid.grid_columnconfigure(2, weight=1)  # Status
+            self.retention_grid.grid_columnconfigure(1, weight=3)  # Workloads
+            self.retention_grid.grid_columnconfigure(2, weight=1)  # Mode
+            self.retention_grid.grid_columnconfigure(3, weight=1)  # Distribution
+            self.retention_grid.grid_columnconfigure(4, weight=1)  # Status
 
-            headers = ["Policy Name", "Applicable Workloads", "Status"]
+            headers = ["Policy Name", "Workloads", "Mode", "Distribution", "Status"]
             for col_idx, head_text in enumerate(headers):
                 cell = ctk.CTkFrame(self.retention_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
                 cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
@@ -461,7 +463,10 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                 bg_style = "transparent" if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
 
                 name = policy.get("Name", "N/A")
+                comment = policy.get("Comment", "")
                 workload = policy.get("Workload", "N/A")
+                mode = policy.get("Mode", "Enforce")
+                dist_status = policy.get("DistributionStatus", "Success")
                 
                 # Enabled can be boolean or string
                 enabled_val = policy.get("Enabled", True)
@@ -474,9 +479,17 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
 
                 c0 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c0.grid(row=r_idx, column=0, sticky="nsew", padx=1, pady=1)
+                
+                has_comment = bool(comment and comment != name)
                 lbl_name = ctk.CTkLabel(c0, text=name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
-                lbl_name.pack(padx=10, pady=6, anchor="w")
-                c0.bind("<Configure>", lambda e, l=lbl_name: l.configure(wraplength=e.width - 20))
+                lbl_name.pack(padx=10, pady=(6, 2) if has_comment else 6, anchor="w")
+                
+                if has_comment:
+                    lbl_comment = ctk.CTkLabel(c0, text=comment, font=FONT_BODY_SMALL, text_color=COLOR_TEXT_SUB)
+                    lbl_comment.pack(padx=10, pady=(0, 6), anchor="w")
+                    c0.bind("<Configure>", lambda e, l1=lbl_name, l2=lbl_comment: (l1.configure(wraplength=e.width - 20), l2.configure(wraplength=e.width - 20)))
+                else:
+                    c0.bind("<Configure>", lambda e, l=lbl_name: l.configure(wraplength=e.width - 20))
 
                 c1 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c1.grid(row=r_idx, column=1, sticky="nsew", padx=1, pady=1)
@@ -486,6 +499,14 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
 
                 c2 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
                 c2.grid(row=r_idx, column=2, sticky="nsew", padx=1, pady=1)
-                ctk.CTkLabel(c2, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+                ctk.CTkLabel(c2, text=mode, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+                c3 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c3.grid(row=r_idx, column=3, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(c3, text=dist_status, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+                c4 = ctk.CTkFrame(self.retention_grid, fg_color=bg_style, corner_radius=0)
+                c4.grid(row=r_idx, column=4, sticky="nsew", padx=1, pady=1)
+                ctk.CTkLabel(c4, text=status, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
 
 

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -86,6 +86,7 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.lic_client_secrets = ctk.StringVar()
 
         self.last_licenses_items = []
+        self.on_all_done_callback = None
 
         # Track individual section statuses ('loading', 'success', 'error', None)
         self.status_sku = None
@@ -114,10 +115,10 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         ctk.CTkLabel(self, text="Microsoft 365 Subscribed SKUs & Usage Overview", font=FONT_HEADER_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 5))
         ctk.CTkLabel(self, text="Connect your Microsoft Azure account to authenticate and audit tenant licensing bundle inventories and usage.", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB).pack(anchor="w", pady=(0, 15))
 
-        inputs_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
-        inputs_frame.pack(fill="x", pady=5)
+        self.inputs_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        self.inputs_frame.pack(fill="x", pady=5)
 
-        inner_pad = ctk.CTkFrame(inputs_frame, fg_color="transparent")
+        inner_pad = ctk.CTkFrame(self.inputs_frame, fg_color="transparent")
         inner_pad.pack(fill="x", padx=15, pady=15)
 
         self._create_entry(inner_pad, "Tenant ID", self.lic_tenant_id)
@@ -274,10 +275,14 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
 
         self.btn_lic_submit.configure(state="normal", text="Submit")
 
-        if all(s == "success" for s in states):
+        success = all(s == "success" for s in states)
+        if success:
             self.lbl_lic_status.configure(text="✔ All Inventory and Usage Reports Pulled Successfully!", text_color=COLOR_SUCCESS)
         else:
             self.lbl_lic_status.configure(text="⚠ Some reports failed. Please retry individually.", text_color=COLOR_ERROR)
+
+        if hasattr(self, "on_all_done_callback") and self.on_all_done_callback:
+            self.on_all_done_callback(success)
 
     # -------------------------------------------------------------------------
     # MASTER SUBMIT LOGIC

--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -99,6 +99,11 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
 
         self.build_ui()
 
+        # Bind mouse wheel globally to scroll this tab when hovered
+        self.bind_all("<MouseWheel>", self._handle_global_mousewheel, add="+")
+        self.bind_all("<Button-4>", self._handle_global_mousewheel, add="+")
+        self.bind_all("<Button-5>", self._handle_global_mousewheel, add="+")
+
     def _create_entry(self, parent, label, var, show=None):
         f = ctk.CTkFrame(parent, fg_color="transparent")
         f.pack(fill="x", pady=5)
@@ -917,3 +922,38 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         except Exception as e:
             async_logger.error("Failed writing export spreadsheet to disk.", exc_info=True)
             messagebox.showerror("Export Error", f"Failed to save file:\n{e}", parent=self)
+
+    def is_descendant(self, parent, widget) -> bool:
+        """Recursively checks if a widget (or its Tkinter path name) is a descendant of parent."""
+        if not widget:
+            return False
+        if isinstance(widget, str):
+            try:
+                widget = self.nametowidget(widget)
+            except Exception:
+                return False
+        if widget == parent:
+            return True
+        if hasattr(widget, "master") and widget.master is not None:
+            return self.is_descendant(parent, widget.master)
+        return False
+
+    def _handle_global_mousewheel(self, event):
+        """Redirects mousewheel scrolling to the tab's parent canvas if hovered."""
+        try:
+            widget = self.winfo_containing(event.x_root, event.y_root)
+        except Exception:
+            return
+
+        if self.is_descendant(self, widget):
+            if event.num == 4:  # Linux scroll up
+                self._parent_canvas.yview("scroll", -1, "units")
+            elif event.num == 5:  # Linux scroll down
+                self._parent_canvas.yview("scroll", 1, "units")
+            else:  # Windows / macOS
+                if sys.platform == "darwin":
+                    # macOS trackpad/mouse delta
+                    self._parent_canvas.yview("scroll", -event.delta, "units")
+                else:
+                    # Windows delta (usually multiple of 120)
+                    self._parent_canvas.yview("scroll", -int(event.delta / 120), "units")


### PR DESCRIPTION
This pull request integrates the clean, restructured OneDrive and SharePoint Storage frames as independent telemetry blocks alongside the tenant-wide Data Security & Governance sensitivity labels grid (complete with hierachical nested sublabels, sorting, and in-memory pagination Prev/Next buttons) and user-friendly Entra ID permission instructions.