### PR TITLE
fix(security): resolve retention policy duration showing N/A in telemetry view

### DIFF
--- a/core/powershell/scripts/get_retention_policies.ps1
+++ b/core/powershell/scripts/get_retention_policies.ps1
@@ -38,8 +38,14 @@ try {
         if ($allRules) {
             foreach ($rule in @($allRules)) {
                 if ($rule.Policy) {
-                    $policyKey = $rule.Policy.ToString()
-                    $ruleMap[$policyKey] = $rule
+                    $rawKey = $rule.Policy.ToString()
+                    $ruleMap[$rawKey] = $rule
+                    
+                    # Extract the policy name if the reference is a DistinguishedName
+                    if ($rawKey -match "CN=([^,]+)") {
+                        $cnKey = $Matches[1]
+                        $ruleMap[$cnKey] = $rule
+                    }
                 }
             }
         }
@@ -57,6 +63,8 @@ try {
                 $rule = $ruleMap[$policy.Name]
             } elseif ($ruleMap.ContainsKey($policy.Identity.ToString())) {
                 $rule = $ruleMap[$policy.Identity.ToString()]
+            } elseif ($policy.Guid -and $ruleMap.ContainsKey($policy.Guid.ToString())) {
+                $rule = $ruleMap[$policy.Guid.ToString()]
             }
 
             if ($rule) {


### PR DESCRIPTION
This Pull Request resolves the bug where the **Duration**, **Action**, and **Trigger** columns in the Retention Compliance Policies grid were showing `N/A` after the bulk-query optimizations were merged.

### The Cause:
When we optimized the PowerShell scanner to query all compliance rules in bulk to build a local map (`$ruleMap`), we indexed the rules by the string representation of `$rule.Policy`. However, the Purview backend returns the policy association as a DistinguishedName (e.g. `CN=Retention policy 1,CN=CompliancePolicies,...`) or GUID rather than the simple policy name. When the loop queried the map using `$policy.Name` (e.g. `"Retention policy 1"`), the lookup failed to match.

### The Fix:
Updates `get_retention_policies.ps1` to extract the common name (CN) from the policy's DistinguishedName using regex, mapping the rules by both the full DistinguishedName, Azure GUID, and extracted Policy Name. It also adds GUID string matching as a fallback in the lookup loop.