### PR TITLE
feat(telemetry): add height scale slider and reduce font sizes for Power Automate chart

### DIFF
--- a/telemetry/license_usage.py
+++ b/telemetry/license_usage.py
@@ -294,8 +294,31 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
             command=self.export_complex_flows, state="disabled"
         )
         self.btn_export_pa.pack(side="right")
+        
+        # Height control slider for Power Automate Chart (packed above the chart dynamically)
+        self.pa_height_var = ctk.DoubleVar(value=400)
+        self.pa_slider_frame = ctk.CTkFrame(self.pa_inner, fg_color="transparent")
+        
+        self.slider_pa_height = ctk.CTkSlider(
+            self.pa_slider_frame, from_=200, to=800, number_of_steps=60,
+            variable=self.pa_height_var, width=120, height=16,
+            command=self._on_pa_height_slider_change
+        )
+        self.slider_pa_height.pack(side="right")
+        
+        self.lbl_pa_height = ctk.CTkLabel(self.pa_slider_frame, text="Height: 400px", font=FONT_BODY_SMALL, text_color=COLOR_TEXT_SUB)
+        self.lbl_pa_height.pack(side="right", padx=(0, 10))
+        
         self.pa_state_frame = ctk.CTkFrame(self.pa_inner, fg_color="transparent")
         self.pa_grid_frame = ctk.CTkFrame(self.pa_inner, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        # Chart container with fixed height and pack propagation disabled
+        self.pa_chart_container = ctk.CTkFrame(
+            self.pa_inner, fg_color=COLOR_SURFACE,
+            border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8,
+            height=400
+        )
+        self.pa_chart_container.pack_propagate(False)
 
 
         self._hide_all_grids()
@@ -313,8 +336,10 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.onedrive_view.reset_view()
         self.security_gov_view.reset_view()
         self.pa_section.pack_forget()
+        self.pa_slider_frame.pack_forget()
+        self.pa_chart_container.pack_forget()
 
-        for grid in [self.lic_grid_frame, self.o365_grid_frame, self.o365_trend_grid_frame, self.m365_grid_frame, self.pa_grid_frame]:
+        for grid in [self.lic_grid_frame, self.o365_grid_frame, self.o365_trend_grid_frame, self.m365_grid_frame, self.pa_grid_frame, self.pa_chart_container]:
             for w in grid.winfo_children():
                 w.destroy()
 
@@ -737,6 +762,8 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         self.status_pa = "loading"
         self.pa_section.pack(fill="x", expand=True, pady=(20, 10))
         self.pa_grid_frame.pack_forget()
+        self.pa_slider_frame.pack_forget()
+        self.pa_chart_container.pack_forget()
         self._set_state_loading(self.pa_state_frame, "Scanning Power Automate flows...")
         threading.Thread(target=self._execute_pa_worker, args=(tenant, clients[0], secrets[0]), daemon=True).start()
 
@@ -822,15 +849,16 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
 
         # 2. Charts Section
         if total_flows > 0:
-            charts_frame = ctk.CTkFrame(self.pa_grid_frame, fg_color="transparent")
-            charts_frame.pack(fill="x", pady=20)
+            self.pa_slider_frame.pack(fill="x", pady=(10, 0))
+            self.pa_chart_container.pack(fill="x", pady=(5, 20))
+            for w in self.pa_chart_container.winfo_children():
+                w.destroy()
             
             if not MATPLOTLIB_AVAILABLE:
-                ctk.CTkLabel(charts_frame, text="Matplotlib is required to render charts.\nPlease install it using 'pip install matplotlib'.", text_color=COLOR_ERROR).pack(pady=15)
+                ctk.CTkLabel(self.pa_chart_container, text="Matplotlib is required to render charts.\nPlease install it using 'pip install matplotlib'.", text_color=COLOR_ERROR).pack(pady=15)
             else:
                 try:
-                    # Increased size as requested
-                    fig, ax = plt.subplots(figsize=(12, 7), dpi=100)
+                    fig, ax = plt.subplots(figsize=(10, 4), dpi=100)
                     fig.patch.set_facecolor(COLOR_SURFACE)
                     ax.set_facecolor(COLOR_SURFACE)
                     
@@ -867,19 +895,19 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
                     rects1 = ax.bar(x, actives, width, label='Active', color=color_active)
                     rects2 = ax.bar([i + width for i in x], inactives, width, label='Inactive', color=color_inactive)
                     
-                    ax.set_ylabel('Count', color=COLOR_TEXT_MAIN, fontsize=14, fontweight='bold')
-                    ax.set_title('Power Automate Flows Breakdown', color=COLOR_TEXT_MAIN, fontsize=18, fontweight='bold')
+                    ax.set_ylabel('Count', color=COLOR_TEXT_MAIN, fontsize=10, fontweight='bold')
+                    ax.set_title('Power Automate Flows Breakdown', color=COLOR_TEXT_MAIN, fontsize=12, fontweight='bold')
                     ax.set_xticks([i + width/2 for i in x])
-                    ax.set_xticklabels(categories, color=COLOR_TEXT_MAIN, fontsize=14, fontweight='bold')
-                    ax.legend(facecolor=COLOR_SURFACE, edgecolor=COLOR_OUTLINE_LIGHT, labelcolor=COLOR_TEXT_MAIN, prop={'weight':'bold', 'size':12})
+                    ax.set_xticklabels(categories, color=COLOR_TEXT_MAIN, fontsize=10, fontweight='bold')
+                    ax.legend(facecolor=COLOR_SURFACE, edgecolor=COLOR_OUTLINE_LIGHT, labelcolor=COLOR_TEXT_MAIN, prop={'weight':'bold', 'size':9})
                     
-                    ax.bar_label(rects1, padding=3, color=COLOR_TEXT_MAIN, fontsize=14, fontweight='bold')
-                    ax.bar_label(rects2, padding=3, color=COLOR_TEXT_MAIN, fontsize=14, fontweight='bold')
+                    ax.bar_label(rects1, padding=3, color=COLOR_TEXT_MAIN, fontsize=9, fontweight='bold')
+                    ax.bar_label(rects2, padding=3, color=COLOR_TEXT_MAIN, fontsize=9, fontweight='bold')
                     
                     for spine in ax.spines.values():
                         spine.set_color(COLOR_OUTLINE_LIGHT)
                     
-                    ax.tick_params(axis='y', colors=COLOR_TEXT_MAIN, labelsize=12)
+                    ax.tick_params(axis='y', colors=COLOR_TEXT_MAIN, labelsize=9)
                     for label in ax.get_yticklabels():
                         label.set_fontweight('bold')
                     
@@ -887,10 +915,9 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
                     ax.set_ylim(0, max(max_val + 3, int(max_val * 1.3)))
                     
                     fig.tight_layout()
-                    canvas = FigureCanvasTkAgg(fig, master=charts_frame)
+                    canvas = FigureCanvasTkAgg(fig, master=self.pa_chart_container)
                     canvas.draw()
-                    # Allow it to expand more in width
-                    canvas.get_tk_widget().pack(fill="x", padx=50, pady=10)
+                    canvas.get_tk_widget().pack(fill="both", expand=True, padx=20, pady=10)
                     
                 except Exception as e:
                     async_logger.error(f"Error drawing Power Automate charts: {e}", exc_info=True)
@@ -1046,3 +1073,8 @@ class LicenseUsageTab(ctk.CTkScrollableFrame):
         height_val = int(val)
         self.lbl_trend_height.configure(text=f"Height: {height_val}px")
         self.o365_trend_grid_frame.configure(height=height_val)
+
+    def _on_pa_height_slider_change(self, val):
+        height_val = int(val)
+        self.lbl_pa_height.configure(text=f"Height: {height_val}px")
+        self.pa_chart_container.configure(height=height_val)


### PR DESCRIPTION
This Pull Request enhances the Power Automate flow breakdown chart in the License and Telemetry usage dashboard:

1. **Text & Label Size Optimization**: Reduced Matplotlib text size and category labels for a clean and professional look.
2. **Height Scaling Slider**: Added a dynamic height slider directly above the chart layout, allowing users to scale the chart height from 200px to 800px dynamically.
3. **Packing Sequence Bug Fix**: Fixed a bug where consecutive scan fetches caused the chart layout sequence to get scrambled and bypassed the loading screen visibility by explicitly calling pack_forget() on all child containers when loading starts.