### PR TITLE
fix(security): pass correct cert_tenant_id Guid to PowerShellClient in fetch_retention_policies_data

### DIFF
--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -153,7 +153,7 @@ def fetch_retention_policies_data(client_id, client_secret, tenant_id) -> dict:
         from core.powershell.client import PowerShellClient
         from core.powershell.retention import RetentionService
         
-        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id, client_secret=client_secret)
+        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id, client_secret=client_secret, cert_tenant_id=tenant_id)
         retention_service = RetentionService(ps_client)
         policies = retention_service.fetch_retention_policies()
         return {"policies": policies, "error": None}


### PR DESCRIPTION
This Pull Request resolves a certificate not found bug when fetching Retention Compliance Policies:

1. **Root Cause**: The background worker function `fetch_retention_policies_data` instantiated `PowerShellClient` without specifying `cert_tenant_id=tenant_id`. As a result, it fell back to searching for certificates under the primary domain name string instead of the directory named after the Tenant ID Guid, raising a `FileNotFoundError`.
2. **Resolution**: Correctly passed the `cert_tenant_id=tenant_id` Guid parameter to the `PowerShellClient` constructor.