### PR TITLE
feat(telemetry): treat Undetermined client values as active usage in telemetry parsing

### DIFF
--- a/core/graph/reports.py
+++ b/core/graph/reports.py
@@ -165,3 +165,46 @@ class ReportsService:
         """Downloads Exchange email app usage detail CSV report (180 days)."""
         self.download_report("https://graph.microsoft.com/v1.0/reports/getEmailAppUsageUserDetail(period='D180')", "EmailAppUsageUserDetail(180d).csv", output_dir)
 
+    def search_cloud_pst_files(self) -> dict:
+        """Queries Microsoft Graph Search API to locate cloud-stored PST archive files across all active regions."""
+        url = "https://graph.microsoft.com/v1.0/search/query"
+        token_slot = self.client.get_active_token()
+        session = self.client.get_session()
+        
+        headers = {
+            "Authorization": f"Bearer {token_slot['token']}",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+
+        total_hits = []
+        regions = ["NAM", "EUR", "APC"]
+        
+        try:
+            for region in regions:
+                payload = {
+                    "requests": [
+                        {
+                            "entityTypes": ["driveItem"],
+                            "query": {"queryString": "fileextension:pst"},
+                            "from": 0,
+                            "size": 50,
+                            "region": region
+                        }
+                    ]
+                }
+                logger.info(f"Executing Graph Search query for cloud PST archives in region: {region}...")
+                resp = session.post(url, json=payload, headers=headers)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    if "value" in data:
+                        total_hits.extend(data["value"])
+                elif resp.status_code == 400 and "Only valid regions are" in resp.text:
+                    logger.info(f"Region {region} is not active for this tenant. Skipping.")
+                else:
+                    raise ConnectionError(f"Graph Search failed for region {region} (HTTP {resp.status_code}): {resp.text}")
+            
+            return {"value": total_hits}
+        finally:
+            self.client.release_token(token_slot)
+

--- a/core/graph/security.py
+++ b/core/graph/security.py
@@ -98,3 +98,4 @@ class SecurityService:
             self.client.release_token(token_slot)
 
 
+

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -37,7 +37,7 @@ def parse_email_client_support_csv(filepath: str) -> dict:
         df = pd.read_csv(filepath)
         for col in df.columns:
             if col not in ["Report Refresh Date", "User Principal Name", "Display Name", "Last Activity Date", "Is Deleted"]:
-                df[col] = df[col].astype(str).str.strip().str.upper().isin(["TRUE", "1"])
+                df[col] = df[col].astype(str).str.strip().str.upper().isin(["TRUE", "1", "UNDETERMINED"])
                 
         if "Is Deleted" in df.columns:
             df = df[~df["Is Deleted"].astype(str).str.strip().str.upper().isin(["TRUE", "1"])]

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -80,8 +80,8 @@ def parse_email_client_support_csv(filepath: str) -> dict:
         return {}
 
 def run_email_client_pipeline(client_id: str, client_secret: str, tenant_id: str) -> dict:
-    """Pipeline specifically downloading and parsing getEmailAppUsageUserDetail reports."""
-    usage_logger.info("Starting Email Client Support Telemetry Pipeline...")
+    """Pipeline specifically downloading getEmailAppUsageUserDetail reports and discovering PSTs."""
+    usage_logger.info("Starting Email Client Usage and PST Discovery Pipeline...")
     client = GraphClient(
         tenant_id=tenant_id,
         client_ids=client_id,
@@ -96,18 +96,32 @@ def run_email_client_pipeline(client_id: str, client_secret: str, tenant_id: str
     script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
     reports_dir = os.path.join(script_dir, "reports", f"{tenant_id}_{client_id}")
     
+    client_stats = {}
+    client_error = None
     try:
         service.download_email_app_usage_detail(reports_dir)
         client_stats = parse_email_client_support_csv(os.path.join(reports_dir, "EmailAppUsageUserDetail(180d).csv"))
     except Exception as e:
         usage_logger.warning(f"Could not retrieve/parse Email App Usage report: {e}")
-        client_stats = {}
+        client_error = str(e)
+
+    pst_cloud = {}
+    pst_error = None
+    try:
+        pst_cloud = service.search_cloud_pst_files()
+    except Exception as e:
+        pst_error = str(e)
 
     client.close()
-    return {"client_adoption": client_stats}
+    return {
+        "client_adoption": client_stats,
+        "client_error": client_error,
+        "pst_cloud_data": pst_cloud,
+        "pst_error": pst_error
+    }
 
 class EmailClientSupportFrame(ctk.CTkFrame):
-    """Self-contained CustomTkinter component rendering Supported Email Clients UI."""
+    """Self-contained CustomTkinter component rendering Email Environment UI."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
         self.semaphore = kwargs.pop("concurrency_semaphore", None)
@@ -127,13 +141,16 @@ class EmailClientSupportFrame(ctk.CTkFrame):
 
         ctk.CTkLabel(
             self.inner_pad,
-            text="Supported Email Clients",
+            text="Email Environment",
             font=FONT_HEADER_SMALL,
             text_color=COLOR_TEXT_MAIN
-        ).pack(anchor="w", pady=(0, 10))
+        ).pack(anchor="w", pady=(0, 15))
 
         self.state_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
         self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+
+        self.sub_title_2 = ctk.CTkLabel(self.inner_pad, text="PST Files", font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
+        self.pst_grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
 
         self.reset_view()
 
@@ -141,9 +158,14 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self.pack_forget()
         self.state_frame.pack_forget()
         self.grid_frame.pack_forget()
+        self.sub_title_2.pack_forget()
+        self.pst_grid_frame.pack_forget()
+        
         for w in self.state_frame.winfo_children():
             w.destroy()
         for w in self.grid_frame.winfo_children():
+            w.destroy()
+        for w in self.pst_grid_frame.winfo_children():
             w.destroy()
 
     def _set_state_loading(self, msg="Loading..."):
@@ -157,7 +179,7 @@ class EmailClientSupportFrame(ctk.CTkFrame):
             w.destroy()
         display_msg = error_msg
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower():
-            display_msg = "Reports telemetry permission required.\nPlease grant 'Reports.Read.All' permission in Microsoft Entra ID."
+            display_msg = "Reports / Search telemetry permission required.\nPlease grant 'Reports.Read.All' and 'Files.Read.All' in Microsoft Entra ID."
 
         ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
         self.state_frame.pack(fill="x", expand=True)
@@ -168,7 +190,8 @@ class EmailClientSupportFrame(ctk.CTkFrame):
 
         self.pack(fill="x", expand=True, pady=10)
         self.grid_frame.pack_forget()
-        self._set_state_loading("Analyzing Email Client Usage reports...")
+        self.pst_grid_frame.pack_forget()
+        self._set_state_loading("Analyzing Email Clients & Discovering PST Files...")
 
         threading.Thread(
             target=self._execute_worker,
@@ -192,51 +215,60 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self.state_frame.pack_forget()
         for w in self.grid_frame.winfo_children():
             w.destroy()
+        for w in self.pst_grid_frame.winfo_children():
+            w.destroy()
 
-        c_adop = data.get("client_adoption", {})
-        if not c_adop:
-            c_adop = {
-                "browser_users": 0, "desktop_win": 0, "desktop_mac": 0, "desktop_mail_mac": 0,
-                "mobile_outlook": 0, "mobile_other": 0, "protocol_imap4": 0, "protocol_pop3": 0, "protocol_smtp": 0
-            }
-
+        # Render Supported Email Clients
         self.grid_frame.pack(fill="x", expand=True)
         self.grid_frame.grid_columnconfigure(0, weight=2)
         self.grid_frame.grid_columnconfigure(1, weight=5)
 
-        headers_client = ["Email Client Classification", "Surfaced Active User Counts & Findings"]
+        headers_client = ["Email Client Classification", "Active User Counts (180-Day Telemetry)"]
         for col_idx, head_text in enumerate(headers_client):
             cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
             cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
             ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
 
-        b_users = c_adop.get("browser_users", 0)
-        d_win = c_adop.get("desktop_win", 0)
-        d_mac = c_adop.get("desktop_mac", 0)
-        m_mac = c_adop.get("desktop_mail_mac", 0)
-        m_out = c_adop.get("mobile_outlook", 0)
-        m_oth = c_adop.get("mobile_other", 0)
-        p_imap = c_adop.get("protocol_imap4", 0)
-        p_smtp = c_adop.get("protocol_smtp", 0)
-        p_pop = c_adop.get("protocol_pop3", 0)
+        client_err = data.get("client_error")
+        if client_err:
+            d_str = f"✖ Error: {client_err}"
+            m_str = f"✖ Error: {client_err}"
+            p_str = f"✖ Error: {client_err}"
+            rows_client = [
+                ("Supported Browser-Based Clients", f"✖ Error: {client_err}"),
+                ("Supported Non-Browser (Desktop)", d_str),
+                ("Supported Non-Browser (Mobile)", m_str),
+                ("Supported Non-Browser (Protocols)", p_str)
+            ]
+        else:
+            c_adop = data.get("client_adoption", {})
+            b_users = c_adop.get("browser_users", 0) if c_adop else 0
+            d_win = c_adop.get("desktop_win", 0) if c_adop else 0
+            d_mac = c_adop.get("desktop_mac", 0) if c_adop else 0
+            m_mac = c_adop.get("desktop_mail_mac", 0) if c_adop else 0
+            m_out = c_adop.get("mobile_outlook", 0) if c_adop else 0
+            m_oth = c_adop.get("mobile_other", 0) if c_adop else 0
+            p_imap = c_adop.get("protocol_imap4", 0) if c_adop else 0
+            p_smtp = c_adop.get("protocol_smtp", 0) if c_adop else 0
+            p_pop = c_adop.get("protocol_pop3", 0) if c_adop else 0
 
-        d_str = (f"• Outlook for Windows: {d_win:,} Users\n"
-                 f"• Outlook for Mac: {d_mac:,} Users\n"
-                 f"• Apple Mail (macOS): {m_mac:,} Users")
+            d_str = (f"• Outlook for Windows: {d_win:,} Users\n"
+                     f"• Outlook for Mac: {d_mac:,} Users\n"
+                     f"• Apple Mail (macOS): {m_mac:,} Users")
 
-        m_str = (f"• Outlook Mobile (iOS/Android): {m_out:,} Users\n"
-                 f"• Native / Other Mobile Apps: {m_oth:,} Users")
+            m_str = (f"• Outlook Mobile (iOS/Android): {m_out:,} Users\n"
+                     f"• Native / Other Mobile Apps: {m_oth:,} Users")
 
-        p_str = (f"• IMAP4 Bi-Directional Sync: {p_imap:,} Users\n"
-                 f"• POP3 Local Download: {p_pop:,} Users\n"
-                 f"• SMTP Automated Relays: {p_smtp:,} Accounts")
+            p_str = (f"• IMAP4 Bi-Directional Sync: {p_imap:,} Users\n"
+                     f"• POP3 Local Download: {p_pop:,} Users\n"
+                     f"• SMTP Automated Relays: {p_smtp:,} Accounts")
 
-        rows_client = [
-            ("Supported Browser-Based Clients", f"• Outlook on the Web (OWA): {b_users:,} Users"),
-            ("Supported Non-Browser (Desktop)", d_str),
-            ("Supported Non-Browser (Mobile)", m_str),
-            ("Supported Non-Browser (Protocols)", p_str)
-        ]
+            rows_client = [
+                ("Supported Browser-Based Clients", f"• Outlook on the Web (OWA): {b_users:,} Users"),
+                ("Supported Non-Browser (Desktop)", d_str),
+                ("Supported Non-Browser (Mobile)", m_str),
+                ("Supported Non-Browser (Protocols)", p_str)
+            ]
 
         for cr_idx, (c_name, c_val) in enumerate(rows_client, start=1):
             bg_c = "transparent" if cr_idx % 2 != 0 else COLOR_SURFACE_VARIANT
@@ -249,6 +281,50 @@ class EmailClientSupportFrame(ctk.CTkFrame):
             cc1.grid(row=cr_idx, column=1, sticky="nsew", padx=1, pady=1)
             ctk.CTkLabel(cc1, text=c_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left").pack(padx=10, pady=10, anchor="nw")
 
+        # 3. Subsection 3: PST Files
+        self.sub_title_2.pack(anchor="w", pady=(25, 10))
+        self.pst_grid_frame.pack(fill="x", expand=True)
+        self.pst_grid_frame.grid_columnconfigure(0, weight=2)
+        self.pst_grid_frame.grid_columnconfigure(1, weight=5)
+
+        headers_pst = ["PST Storage Location", "Discovered File Count & Size"]
+        for col_idx, head_text in enumerate(headers_pst):
+            cell = ctk.CTkFrame(self.pst_grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
+            cell.grid(row=0, column=col_idx, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+        pst_err = data.get("pst_error")
+        if pst_err:
+            cloud_str = f"✖ Error: {pst_err}"
+        else:
+            pst_cloud = data.get("pst_cloud_data", {})
+            cloud_count = 0
+            cloud_bytes = 0
+            if pst_cloud and "value" in pst_cloud:
+                for item in pst_cloud.get("value", []):
+                    for hc in item.get("hitsContainers", []):
+                        cloud_count += hc.get("total", 0)
+                        for hit in hc.get("hits", []):
+                            cloud_bytes += int(hit.get("resource", {}).get("size", 0))
+
+            cloud_size_str = f" ({format_bytes(cloud_bytes)})" if cloud_bytes > 0 else ""
+            cloud_str = f"{cloud_count:,} Files{cloud_size_str}" if cloud_count > 0 else "None Detected"
+
+        rows_pst = [
+            ("Cloud (SharePoint & OneDrive)", cloud_str)
+        ]
+
+        for p_idx, (p_name, p_val) in enumerate(rows_pst, start=1):
+            bg_p = "transparent" if p_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+            
+            pp0 = ctk.CTkFrame(self.pst_grid_frame, fg_color=bg_p, corner_radius=0)
+            pp0.grid(row=p_idx, column=0, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(pp0, text=p_name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=10, anchor="nw")
+
+            pp1 = ctk.CTkFrame(self.pst_grid_frame, fg_color=bg_p, corner_radius=0)
+            pp1.grid(row=p_idx, column=1, sticky="nsew", padx=1, pady=1)
+            ctk.CTkLabel(pp1, text=p_val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left").pack(padx=10, pady=10, anchor="nw")
+
         self.status = "success"
         self.on_status_change()
 
@@ -256,3 +332,4 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self._set_state_error(err_msg)
         self.status = "error"
         self.on_status_change()
+

--- a/telemetry/exchange_online.py
+++ b/telemetry/exchange_online.py
@@ -59,10 +59,6 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.mailbox_view.configure(fg_color="transparent", border_width=0)
         self.mailbox_view.pack(fill="x", expand=True, pady=(0, 5))
 
-        # Separator line 1
-        self.divider = ctk.CTkFrame(self.inner_pad, height=1, fg_color=COLOR_OUTLINE_LIGHT)
-        self.divider.pack(fill="x", pady=10)
-
         # Calendar Telemetry Sub-frame
         self.calendar_view = CalendarTelemetryFrame(
             master=self.inner_pad,
@@ -73,10 +69,6 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         )
         self.calendar_view.configure(fg_color="transparent", border_width=0)
         self.calendar_view.pack(fill="x", expand=True, pady=(0, 5))
-
-        # Separator line 2
-        self.divider2 = ctk.CTkFrame(self.inner_pad, height=1, fg_color=COLOR_OUTLINE_LIGHT)
-        self.divider2.pack(fill="x", pady=10)
 
         # Organization-wide Apps Sub-frame
         self.apps_view = ExchangeAppsFrame(
@@ -97,8 +89,6 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.mailbox_view.reset_view()
         self.calendar_view.reset_view()
         self.apps_view.reset_view()
-        self.divider.pack_forget()
-        self.divider2.pack_forget()
 
     def trigger_fetch(self, tenant, client_id, client_secret):
         """Displays container and delegates fetches to all sub-views."""
@@ -106,8 +96,6 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.on_status_change()
 
         self.pack(fill="x", expand=True, pady=10)
-        self.divider.pack(fill="x", pady=10)
-        self.divider2.pack(fill="x", pady=10)
 
         self.mailbox_view.trigger_fetch(tenant, client_id, client_secret)
         self.calendar_view.trigger_fetch(tenant, client_id, client_secret)


### PR DESCRIPTION
### Overview
Configures the M365 email telemetry parser to count 'Undetermined' client values as active Connections.

### Rationale
Active user mailboxes on M365 developer/trial sandboxes or mailboxes without recent mail transport flow often display 'Undetermined' for the specific client application. Evaluating these records as active connections ensures user-agent resolution limitations are accounted for on the dashboard.