### PR TITLE
feat: Add Exchange Connector data

### DIFF
--- a/core/powershell/exchange_connectors.py
+++ b/core/powershell/exchange_connectors.py
@@ -1,0 +1,46 @@
+import json
+import logging
+from core.powershell.client import PowerShellClient
+
+logger = logging.getLogger("ExchangeConnectorsService")
+
+class ExchangeConnectorsService:
+    def __init__(self, client: PowerShellClient):
+        self.client = client
+
+    def fetch_exchange_connectors(self) -> dict:
+        """Executes get_connectors.ps1 and parses the JSON response."""
+        logger.info("Executing Exchange Connectors PowerShell script...")
+        try:
+            cert_path = self.client.locate_certificate()
+        except FileNotFoundError as e:
+            logger.error(str(e))
+            raise RuntimeError(str(e))
+            
+        args = [
+            "-AppId", self.client.client_id,
+            "-Organization", self.client.tenant_id,
+            "-CertificatePath", cert_path
+        ]
+        
+        if self.client.cert_password:
+            args.extend(["-CertificatePassword", self.client.cert_password])
+            
+        try:
+            output = self.client.execute_script("scripts/get_connectors.ps1", args)
+            
+            # Extract JSON from output
+            json_str = output
+            if "{" in output:
+                json_str = output[output.find("{"):]
+            
+            if not json_str.strip():
+                return {"InboundConnectors": [], "OutboundConnectors": [], "Errors": {}}
+                
+            return json.loads(json_str)
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse Exchange Connectors JSON: {e}")
+            raise RuntimeError(f"Failed to parse Exchange Connectors data: {e}")
+        except Exception as e:
+            logger.error(f"Exchange Connectors retrieval failed: {e}")
+            raise RuntimeError(f"Exchange Connectors retrieval failed: {e}")

--- a/core/powershell/scripts/get_connectors.ps1
+++ b/core/powershell/scripts/get_connectors.ps1
@@ -1,0 +1,76 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$AppId,
+    [Parameter(Mandatory=$true)]
+    [string]$Organization,
+    [Parameter(Mandatory=$true)]
+    [string]$CertificatePath,
+    [Parameter(Mandatory=$false)]
+    [string]$CertificatePassword
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+    throw "ExchangeOnlineManagement PowerShell module is not installed. Please install it beforehand by running: Install-Module -Name ExchangeOnlineManagement -Scope CurrentUser"
+}
+
+Import-Module ExchangeOnlineManagement
+
+# Connect to Exchange Online using App-Only Cert Auth
+if ($CertificatePassword) {
+    $secPassword = ConvertTo-SecureString -String $CertificatePassword -AsPlainText -Force
+    Connect-ExchangeOnline -CertificateFilePath $CertificatePath -CertificatePassword $secPassword -AppId $AppId -Organization $Organization -ShowBanner:$false -WarningAction SilentlyContinue
+} else {
+    Connect-ExchangeOnline -CertificateFilePath $CertificatePath -AppId $AppId -Organization $Organization -ShowBanner:$false -WarningAction SilentlyContinue
+}
+
+try {
+    $errors = @{}
+    $inbound = @()
+    $outbound = @()
+
+    try {
+        $inboundRaw = Get-InboundConnector -ErrorAction Stop
+        if ($inboundRaw) {
+            foreach ($conn in @($inboundRaw)) {
+                $inbound += @{
+                    Name = $conn.Identity
+                    Enabled = $conn.Enabled
+                    ConnectorType = $conn.ConnectorType
+                    SenderDomains = ($conn.SenderDomains -join ", ")
+                    RequireTls = $conn.RequireTls
+                }
+            }
+        }
+    } catch {
+        $errors["InboundConnectors"] = $_.Exception.Message
+    }
+
+    try {
+        $outboundRaw = Get-OutboundConnector -ErrorAction Stop
+        if ($outboundRaw) {
+            foreach ($conn in @($outboundRaw)) {
+                $outbound += @{
+                    Name = $conn.Identity
+                    Enabled = $conn.Enabled
+                    RecipientDomains = ($conn.RecipientDomains -join ", ")
+                    SmartHosts = ($conn.SmartHosts -join ", ")
+                    UseMxRecord = $conn.UseMxRecord
+                }
+            }
+        }
+    } catch {
+        $errors["OutboundConnectors"] = $_.Exception.Message
+    }
+
+    $result = [PSCustomObject]@{
+        InboundConnectors = $inbound
+        OutboundConnectors = $outbound
+        Errors = $errors
+    }
+    $result | ConvertTo-Json -Depth 5
+}
+finally {
+    Disconnect-ExchangeOnline -Confirm:$false -ErrorAction SilentlyContinue
+}

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -226,6 +226,7 @@ def fetch_authentication_data(client_id, client_secret, tenant_id) -> dict:
             pass
 
 
+
 class DataSecurityGovernanceFrame(ctk.CTkFrame):
     """Self-contained customtkinter component wrapping Data Security & Governance UI."""
     
@@ -526,12 +527,14 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.auth_header_frame.pack_forget()
         self.auth_grid.pack_forget()
         
+
         for w in self.labels_grid.winfo_children():
             w.destroy()
         for w in self.retention_grid.winfo_children():
             w.destroy()
         for w in self.auth_grid.winfo_children():
             w.destroy()
+
             
         self.current_page = 0
         self.last_labels_data = None
@@ -604,6 +607,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.auth_header_frame.pack(fill="x", pady=(20, 10))
         self.auth_grid.pack(fill="x", expand=True, pady=(0, 15))
         self._set_auth_loading("Retrieving Conditional Access authentication mechanics...")
+
         
         # Pack eDiscovery Cases Section (static, show immediately)
         self.ediscovery_header_frame.pack(fill="x", pady=(20, 10))
@@ -633,6 +637,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
             args=(tenant, client_id, client_secret),
             daemon=True
         ).start()
+
 
     def _execute_labels_worker(self, tenant: str, client_id: str, client_secret: str):
         usage_logger.info("Executing thread: _execute_labels_worker")
@@ -666,6 +671,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         finally:
             if self.semaphore:
                 self.semaphore.release()
+
 
     def _set_auth_loading(self, msg="Loading..."):
         for w in self.auth_grid.winfo_children():
@@ -837,6 +843,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
                     c = ctk.CTkFrame(self.auth_grid, fg_color=bg_style, corner_radius=0)
                     c.grid(row=r_idx, column=c_idx, sticky="nsew", padx=0, pady=(0, 1))
                     ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=180).pack(padx=10, pady=12, anchor="nw")
+
 
 
 

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -144,6 +144,9 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
         self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
 
+        # Missing UI Header added here to match Exchange Online aesthetics
+        ctk.CTkLabel(self.inner_pad, text="Email Client Support & Legacy PST Data", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
+
         self.sub_title_1 = ctk.CTkLabel(self.inner_pad, text="Email Client Classification", font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
         self.state_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
         self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
@@ -225,8 +228,8 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         # Render Supported Email Clients
         self.sub_title_1.pack(anchor="w", pady=(5, 10))
         self.grid_frame.pack(fill="x", expand=True)
-        self.grid_frame.grid_columnconfigure(0, weight=2)
-        self.grid_frame.grid_columnconfigure(1, weight=5)
+        for i in range(2):
+            self.grid_frame.grid_columnconfigure(i, weight=1)
 
         headers_client = ["Email Client Classification", "Active User Counts (180-Day Telemetry)"]
         for col_idx, head_text in enumerate(headers_client):

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -144,14 +144,11 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
         self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
 
-        # Missing UI Header added here to match Exchange Online aesthetics
-        ctk.CTkLabel(self.inner_pad, text="Email Client Support & Legacy PST Data", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(anchor="w", pady=(0, 10))
-
-        self.sub_title_1 = ctk.CTkLabel(self.inner_pad, text="Email Client Classification", font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
+        self.sub_title_1 = ctk.CTkLabel(self.inner_pad, text="Email Client Classification", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN)
         self.state_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
         self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
 
-        self.sub_title_2 = ctk.CTkLabel(self.inner_pad, text="PST Files", font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN)
+        self.sub_title_2 = ctk.CTkLabel(self.inner_pad, text="PST Files", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN)
         self.pst_grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
 
         self.reset_view()

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -172,13 +172,31 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         for w in self.pst_grid_frame.winfo_children():
             w.destroy()
 
-    def _set_state_loading(self, msg="Loading..."):
-        for w in self.state_frame.winfo_children():
+    def _set_state_loading(self):
+        self.state_frame.pack_forget()
+        
+        self.sub_title_1.pack(anchor="w", pady=(5, 10))
+        self.grid_frame.pack(fill="x", expand=True)
+        for w in self.grid_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
-        self.state_frame.pack(fill="x", expand=True)
+        f1 = ctk.CTkFrame(self.grid_frame, fg_color="transparent")
+        ctk.CTkLabel(f1, text="⏳ Analyzing Email Clients...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        f1.pack(fill="x", expand=True)
+
+        self.sub_title_2.pack(anchor="w", pady=(20, 10))
+        self.pst_grid_frame.pack(fill="x", expand=True)
+        for w in self.pst_grid_frame.winfo_children():
+            w.destroy()
+        f2 = ctk.CTkFrame(self.pst_grid_frame, fg_color="transparent")
+        ctk.CTkLabel(f2, text="⏳ Discovering PST Files...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        f2.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
+        self.sub_title_1.pack_forget()
+        self.grid_frame.pack_forget()
+        self.sub_title_2.pack_forget()
+        self.pst_grid_frame.pack_forget()
+        
         for w in self.state_frame.winfo_children():
             w.destroy()
         display_msg = error_msg
@@ -193,9 +211,7 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         self.on_status_change()
 
         self.pack(fill="x", expand=True, pady=10)
-        self.grid_frame.pack_forget()
-        self.pst_grid_frame.pack_forget()
-        self._set_state_loading("Analyzing Email Clients & Discovering PST Files...")
+        self._set_state_loading()
 
         threading.Thread(
             target=self._execute_worker,

--- a/telemetry/exchange_connectors_ui.py
+++ b/telemetry/exchange_connectors_ui.py
@@ -1,0 +1,258 @@
+import customtkinter as ctk
+import threading
+import logging
+import traceback
+import webbrowser
+from telemetry.styles import *
+
+usage_logger = logging.getLogger("ExchangeConnectorsUI")
+
+def fetch_exchange_connectors_data(client_id, client_secret, tenant_id) -> dict:
+    """Fetch Exchange Online Inbound and Outbound Connectors."""
+    usage_logger.info("Starting Exchange Connectors fetch...")
+    
+    tenant_domain = tenant_id
+    try:
+        from core.graph.client import GraphClient
+        client = GraphClient(
+            tenant_id=tenant_id,
+            client_ids=client_id,
+            client_secrets=client_secret,
+            concurrency=1,
+            retries=3,
+            backoff=2
+        )
+        client.authenticate()
+        from core.graph.directory import DirectoryService
+        dir_svc = DirectoryService(client)
+        tenant_domain = dir_svc.get_tenant_primary_domain()
+        usage_logger.info(f"Retrieved primary tenant domain for Connectors: {tenant_domain}")
+    except Exception as e:
+        usage_logger.warning(f"Could not retrieve tenant domain. Falling back to Tenant ID Guid: {e}")
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+            
+    try:
+        from core.powershell.client import PowerShellClient
+        from core.powershell.exchange_connectors import ExchangeConnectorsService
+        
+        ps_client = PowerShellClient(tenant_id=tenant_domain, client_id=client_id, client_secret=client_secret, cert_tenant_id=tenant_id)
+        connector_svc = ExchangeConnectorsService(ps_client)
+        data = connector_svc.fetch_exchange_connectors()
+        return {"connectors": data, "error": None}
+    except Exception as e:
+        usage_logger.error("Failed to fetch Exchange Connectors via PowerShell", exc_info=True)
+        return {"connectors": None, "error": str(e)}
+
+class ExchangeConnectorsFrame(ctk.CTkFrame):
+    """Self-contained component for rendering Exchange Online Connectors routing logic matching ExchangeOnline UI standards."""
+    def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
+        self.semaphore = kwargs.pop("concurrency_semaphore", None)
+        super().__init__(master, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=12, **kwargs)
+        self.log_msg = log_callback
+        self.get_credentials = credentials_callback
+        self.on_status_change = status_change_callback
+        self.status = None
+
+        self.build_ui()
+
+    def build_ui(self):
+        """Creates card container for the tab."""
+        self.pack(fill="x", expand=True, pady=10)
+        
+        self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
+        self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
+        
+        self.header_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.header_frame.pack(fill="x", pady=(0, 10))
+        
+        self.title_lbl = ctk.CTkLabel(
+            self.header_frame,
+            text="Exchange Connectors (Inbound & Outbound Routing)",
+            font=FONT_HEADER_SMALL,
+            text_color=COLOR_TEXT_MAIN
+        )
+        self.title_lbl.pack(side="left", anchor="w")
+        
+        # Link label redirecting to EAC Connectors
+        self.link_lbl = ctk.CTkLabel(
+            self.header_frame,
+            text="Open Exchange Admin Center ↗",
+            font=FONT_BODY_BOLD,
+            text_color=COLOR_PRIMARY,
+            cursor="hand2"
+        )
+        self.link_lbl.pack(side="left", anchor="w", padx=(15, 0))
+        self.link_lbl.bind("<Button-1>", lambda e: webbrowser.open("https://admin.cloud.microsoft/exchange?#/connectors"))
+        self.link_lbl.bind("<Enter>", lambda e: self.link_lbl.configure(text_color=COLOR_PRIMARY_HOVER))
+        self.link_lbl.bind("<Leave>", lambda e: self.link_lbl.configure(text_color=COLOR_PRIMARY))
+        
+        self.state_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        self.reset_view()
+
+    def reset_view(self):
+        self.pack_forget()
+        self.state_frame.pack_forget()
+        self.grid_frame.pack_forget()
+        
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+    def _set_state_loading(self, msg="Loading..."):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _set_state_error(self, error_msg):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+
+        display_msg = error_msg
+        if "is not installed or not in PATH" in error_msg.lower() or "pwsh" in error_msg.lower():
+            display_msg = "PowerShell Core ('pwsh') is not installed or configured on this machine."
+        elif "exchangeonlinemanagement" in error_msg.lower():
+            display_msg = "ExchangeOnlineManagement PowerShell module is missing."
+
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _retry_fetch(self):
+        tenant, clients, secrets = self.get_credentials()
+        if tenant:
+            self.trigger_fetch(tenant, clients[0], secrets[0])
+
+    def trigger_fetch(self, tenant, client_id, client_secret):
+        usage_logger.info("Exchange Connectors trigger_fetch called. Spawning background thread...")
+        self.status = "loading"
+        self.on_status_change()
+        
+        self.pack(fill="x", expand=True, pady=10)
+        self.grid_frame.pack_forget()
+        
+        self._set_state_loading("Retrieving Exchange Connectors routing configurations...")
+        
+        threading.Thread(
+            target=self._execute_worker,
+            args=(tenant, client_id, client_secret),
+            daemon=True
+        ).start()
+
+    def _execute_worker(self, tenant: str, client_id: str, client_secret: str):
+        usage_logger.info("Executing thread: _execute_connectors_worker")
+        if self.semaphore:
+            self.semaphore.acquire()
+        try:
+            res = fetch_exchange_connectors_data(client_id, client_secret, tenant)
+            self.after(0, self._handle_result, res)
+        finally:
+            if self.semaphore:
+                self.semaphore.release()
+
+    def _handle_result(self, result: dict):
+        self.state_frame.pack_forget()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+            
+        connectors_data = result.get("connectors")
+        err = result.get("error")
+        
+        if err:
+            self.status = "error"
+            self._set_state_error(err)
+        else:
+            ps_errs = connectors_data.get("Errors", {}) if connectors_data else {}
+            if ps_errs:
+                err_msg = "\n".join([f"{k}: {v}" for k,v in ps_errs.items()])
+                self.status = "error"
+                self._set_state_error(f"PowerShell Execution Error:\n{err_msg}")
+            else:
+                self.status = "success"
+                self.grid_frame.pack(fill="x", expand=True)
+                self._render_card(connectors_data)
+                
+        self.on_status_change()
+
+    def _render_card(self, connectors_data: dict):
+        if not connectors_data:
+            return
+            
+        inbound = connectors_data.get("InboundConnectors", [])
+        outbound = connectors_data.get("OutboundConnectors", [])
+        
+        if not inbound and not outbound:
+            self.grid_frame.configure(fg_color=COLOR_SURFACE, border_width=1, border_color=COLOR_OUTLINE_LIGHT, corner_radius=8)
+            ctk.CTkLabel(self.grid_frame, text="N/A (No Exchange Connectors configured)", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB).pack(padx=20, pady=20, anchor="w")
+            return
+            
+        # Inbound Connectors Section
+        if inbound:
+            in_header = ctk.CTkFrame(self.grid_frame, fg_color="transparent")
+            in_header.pack(fill="x", padx=10, pady=(10, 5))
+            ctk.CTkLabel(in_header, text="Inbound Routing (On-Premises / Third-Party Filter to Exchange Online)", font=FONT_BODY_BOLD, text_color=COLOR_PRIMARY).pack(side="left")
+            
+            in_grid = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_SURFACE, corner_radius=0)
+            in_grid.pack(fill="x", padx=10, pady=(0, 15))
+            
+            headers_in = ["Connector Name", "Status", "Connector Type", "Sender Domains", "Require TLS"]
+            for i in range(5):
+                in_grid.grid_columnconfigure(i, weight=1)
+                
+            for col_idx, head_text in enumerate(headers_in):
+                cell = ctk.CTkFrame(in_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
+                cell.grid(row=0, column=col_idx, sticky="nsew", padx=0, pady=(0, 1))
+                ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+                
+            for r_idx, conn in enumerate(inbound, start=1):
+                bg_style = COLOR_SURFACE if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+                vals = [
+                    conn.get("Name", "N/A"),
+                    "🟢 Enabled" if conn.get("Enabled") else "🔴 Disabled",
+                    conn.get("ConnectorType", "N/A"),
+                    conn.get("SenderDomains", "N/A") or "N/A",
+                    "Yes" if conn.get("RequireTls") else "No"
+                ]
+                for c_idx, val in enumerate(vals):
+                    c = ctk.CTkFrame(in_grid, fg_color=bg_style, corner_radius=0)
+                    c.grid(row=r_idx, column=c_idx, sticky="nsew", padx=0, pady=(0, 1))
+                    ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=180).pack(padx=10, pady=12, anchor="nw")
+
+        # Outbound Connectors Section
+        if outbound:
+            out_header = ctk.CTkFrame(self.grid_frame, fg_color="transparent")
+            out_header.pack(fill="x", padx=10, pady=(10, 5))
+            ctk.CTkLabel(out_header, text="Outbound Routing (Exchange Online to On-Premises / Third-Party Gateway)", font=FONT_BODY_BOLD, text_color=COLOR_PRIMARY).pack(side="left")
+            
+            out_grid = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_SURFACE, corner_radius=0)
+            out_grid.pack(fill="x", padx=10, pady=(0, 10))
+            
+            headers_out = ["Connector Name", "Status", "Recipient Domains", "Smart Hosts", "Use MX Record"]
+            for i in range(5):
+                out_grid.grid_columnconfigure(i, weight=1)
+                
+            for col_idx, head_text in enumerate(headers_out):
+                cell = ctk.CTkFrame(out_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
+                cell.grid(row=0, column=col_idx, sticky="nsew", padx=0, pady=(0, 1))
+                ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+                
+            for r_idx, conn in enumerate(outbound, start=1):
+                bg_style = COLOR_SURFACE if r_idx % 2 != 0 else COLOR_SURFACE_VARIANT
+                vals = [
+                    conn.get("Name", "N/A"),
+                    "🟢 Enabled" if conn.get("Enabled") else "🔴 Disabled",
+                    conn.get("RecipientDomains", "N/A") or "N/A",
+                    conn.get("SmartHosts", "N/A") or "N/A",
+                    "Yes" if conn.get("UseMxRecord") else "No"
+                ]
+                for c_idx, val in enumerate(vals):
+                    c = ctk.CTkFrame(out_grid, fg_color=bg_style, corner_radius=0)
+                    c.grid(row=r_idx, column=c_idx, sticky="nsew", padx=0, pady=(0, 1))
+                    ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=180).pack(padx=10, pady=12, anchor="nw")

--- a/telemetry/exchange_online.py
+++ b/telemetry/exchange_online.py
@@ -45,7 +45,7 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         # Uber Title Heading
         ctk.CTkLabel(
             self.inner_pad,
-            text="Emails & Calendar",
+            text="Email, Calendar and Contacts",
             font=FONT_HEADER_SMALL,
             text_color=COLOR_TEXT_MAIN
         ).pack(anchor="w", pady=(0, 5))

--- a/telemetry/exchange_online.py
+++ b/telemetry/exchange_online.py
@@ -20,6 +20,7 @@ from telemetry.mailbox_usage import MailboxUsageFrame
 from telemetry.calendar_telemetry import CalendarTelemetryFrame
 from telemetry.exchange_apps import ExchangeAppsFrame
 from telemetry.email_client_support import EmailClientSupportFrame
+from telemetry.exchange_connectors_ui import ExchangeConnectorsFrame
 
 class ExchangeOnlineFrame(ctk.CTkFrame):
     """Uber section container hosting Mailbox, Calendar, Apps, and Email Client telemetry frames vertically stacked."""
@@ -82,6 +83,17 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.apps_view.configure(fg_color="transparent", border_width=0)
         self.apps_view.pack(fill="x", expand=True, pady=(0, 5))
 
+        # Exchange Connectors Sub-frame
+        self.connectors_view = ExchangeConnectorsFrame(
+            master=self.inner_pad,
+            log_callback=self.log_msg,
+            credentials_callback=self.get_credentials,
+            status_change_callback=self._check_overall_status,
+            concurrency_semaphore=self.semaphore
+        )
+        self.connectors_view.configure(fg_color="transparent", border_width=0)
+        self.connectors_view.pack(fill="x", expand=True, pady=(0, 5))
+
         # Email Client Support Sub-frame (combining supported email clients and PST files)
         self.email_clients_view = EmailClientSupportFrame(
             master=self.inner_pad,
@@ -101,6 +113,7 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.mailbox_view.reset_view()
         self.calendar_view.reset_view()
         self.apps_view.reset_view()
+        self.connectors_view.reset_view()
         self.email_clients_view.reset_view()
 
     def trigger_fetch(self, tenant, client_id, client_secret):
@@ -113,6 +126,7 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         self.mailbox_view.trigger_fetch(tenant, client_id, client_secret)
         self.calendar_view.trigger_fetch(tenant, client_id, client_secret)
         self.apps_view.trigger_fetch(tenant, client_id, client_secret)
+        self.connectors_view.trigger_fetch(tenant, client_id, client_secret)
         self.email_clients_view.trigger_fetch(tenant, client_id, client_secret)
 
     def _check_overall_status(self):
@@ -121,6 +135,7 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
             self.mailbox_view.status,
             self.calendar_view.status,
             self.apps_view.status,
+            self.connectors_view.status,
             self.email_clients_view.status
         ]
         if "loading" in sub_statuses:


### PR DESCRIPTION
This PR extracts the Exchange Connectors logic from Data Security & Governance and moves it into the Exchange Online Uber container. Includes UI padding fixes, backend PowerShell integrations, and a redirect link to the EAC.