### PR TITLE
feat(ui): Standardize linear loaders and fix Mail Security layout

### DIFF
--- a/telemetry/active_users_usage.py
+++ b/telemetry/active_users_usage.py
@@ -249,6 +249,9 @@ def run_m365_pipeline(client_id, client_secret, tenant_id):
 # =================================================================================
 
 class ActiveUsersUsageFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained component wrapping O365 Active Users Usage UI."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -287,7 +290,11 @@ class ActiveUsersUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -298,7 +305,7 @@ class ActiveUsersUsageFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -444,7 +451,11 @@ class ActiveUsersTrendFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -455,7 +466,7 @@ class ActiveUsersTrendFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -607,7 +618,11 @@ class M365AppUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -618,7 +633,7 @@ class M365AppUsageFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/calendar_telemetry.py
+++ b/telemetry/calendar_telemetry.py
@@ -157,7 +157,10 @@ class CalendarTelemetryFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=(20, 5))
+        self.progress = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        self.progress.pack(pady=(0, 20))
+        self.progress.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):

--- a/telemetry/data_security_governance.py
+++ b/telemetry/data_security_governance.py
@@ -228,6 +228,9 @@ def fetch_authentication_data(client_id, client_secret, tenant_id) -> dict:
 
 
 class DataSecurityGovernanceFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained customtkinter component wrapping Data Security & Governance UI."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -547,7 +550,11 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         for w in self.labels_grid.winfo_children():
             w.destroy()
         self.labels_state_frame = ctk.CTkFrame(self.labels_grid, fg_color="transparent")
-        ctk.CTkLabel(self.labels_state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.labels_state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.labels_state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.labels_state_frame.pack(fill="x", expand=True)
 
     def _set_labels_error(self, error_msg):
@@ -564,7 +571,11 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         for w in self.retention_grid.winfo_children():
             w.destroy()
         self.retention_state_frame = ctk.CTkFrame(self.retention_grid, fg_color="transparent")
-        ctk.CTkLabel(self.retention_state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.retention_state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.retention_state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.retention_state_frame.pack(fill="x", expand=True)
 
     def _set_retention_error(self, error_msg):
@@ -590,7 +601,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self.status = "loading"
         self.on_status_change()
         
-        self.pack(fill="x", expand=True, pady=(20, 10))
+        self.pack(fill="x", expand=True, pady=(20, 5))
         
         # Pack Sensitivity Labels Section
         self.labels_header_frame.pack(fill="x", pady=(0, 10))
@@ -599,18 +610,18 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         self._set_labels_loading("Retrieving Sensitivity labels...")
         
         # Pack Retention Policies Section
-        self.retention_header_frame.pack(fill="x", pady=(20, 10))
+        self.retention_header_frame.pack(fill="x", pady=(20, 5))
         self.retention_grid.pack(fill="x", expand=True, pady=(0, 15))
         self._set_retention_loading("Retrieving Retention policies...")
         
         # Pack Authentication Section
-        self.auth_header_frame.pack(fill="x", pady=(20, 10))
+        self.auth_header_frame.pack(fill="x", pady=(20, 5))
         self.auth_grid.pack(fill="x", expand=True, pady=(0, 15))
         self._set_auth_loading("Retrieving Conditional Access authentication mechanics...")
 
         
         # Pack eDiscovery Cases Section (static, show immediately)
-        self.ediscovery_header_frame.pack(fill="x", pady=(20, 10))
+        self.ediscovery_header_frame.pack(fill="x", pady=(20, 5))
         self.ediscovery_body_frame.pack(fill="x", expand=True, pady=(0, 15))
         
         self.btn_export_labels.configure(state="disabled")
@@ -677,7 +688,11 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         for w in self.auth_grid.winfo_children():
             w.destroy()
         self.auth_state_frame = ctk.CTkFrame(self.auth_grid, fg_color="transparent")
-        ctk.CTkLabel(self.auth_state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.auth_state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.auth_state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.auth_state_frame.pack(fill="x", expand=True)
 
     def _set_auth_error(self, error_msg):
@@ -687,7 +702,7 @@ class DataSecurityGovernanceFrame(ctk.CTkFrame):
         display_msg = error_msg
         if "401" in error_msg or "403" in error_msg or "permission" in error_msg.lower() or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower() or "policy.read" in error_msg.lower():
             display_msg = "Conditional Access telemetry permission required.\nPlease grant the 'Policy.Read.All' (or 'Policy.Read') application permission to your App Registration in Microsoft Entra ID."
-        ctk.CTkLabel(self.auth_state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.auth_state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.auth_state_frame, text="Try Again", command=self._retry_auth_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.auth_state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/directory.py
+++ b/telemetry/directory.py
@@ -30,6 +30,9 @@ usage_logger = logging.getLogger("M365TelemetryAsyncLogger")
 from telemetry.styles import *
 
 class DirectoryFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained customtkinter component wrapping Directory summary (e.g. Domains, Users & Groups) UI."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, retries_var=None, backoff_var=None, **kwargs):
@@ -110,7 +113,11 @@ class DirectoryFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -121,7 +128,7 @@ class DirectoryFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Directory read permissions required.\nPlease grant the 'Directory.Read.All' permission to your App Registration in Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/email_client_support.py
+++ b/telemetry/email_client_support.py
@@ -126,6 +126,9 @@ def run_email_client_pipeline(client_id: str, client_secret: str, tenant_id: str
 
 
 class EmailClientSupportFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained CustomTkinter component rendering Email Environment UI."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -180,15 +183,21 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         for w in self.grid_frame.winfo_children():
             w.destroy()
         f1 = ctk.CTkFrame(self.grid_frame, fg_color="transparent")
-        ctk.CTkLabel(f1, text="⏳ Analyzing Email Clients...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        ctk.CTkLabel(f1, text="⏳ Analyzing Email Clients...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=(20, 5))
+        pb1 = ctk.CTkProgressBar(f1, mode="indeterminate", width=250, fg_color=COLOR_SURFACE_VARIANT, progress_color=COLOR_PRIMARY)
+        pb1.pack(pady=(0, 20))
+        pb1.start()
         f1.pack(fill="x", expand=True)
 
-        self.sub_title_2.pack(anchor="w", pady=(20, 10))
+        self.sub_title_2.pack(anchor="w", pady=(20, 5))
         self.pst_grid_frame.pack(fill="x", expand=True)
         for w in self.pst_grid_frame.winfo_children():
             w.destroy()
         f2 = ctk.CTkFrame(self.pst_grid_frame, fg_color="transparent")
-        ctk.CTkLabel(f2, text="⏳ Discovering PST Files...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        ctk.CTkLabel(f2, text="⏳ Discovering PST Files...", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=(20, 5))
+        pb2 = ctk.CTkProgressBar(f2, mode="indeterminate", width=250, fg_color=COLOR_SURFACE_VARIANT, progress_color=COLOR_PRIMARY)
+        pb2.pack(pady=(0, 20))
+        pb2.start()
         f2.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -203,7 +212,7 @@ class EmailClientSupportFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower():
             display_msg = "Reports / Search telemetry permission required.\nPlease grant 'Reports.Read.All' and 'Files.Read.All' in Microsoft Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         self.state_frame.pack(fill="x", expand=True)
 
     def trigger_fetch(self, tenant, client_id, client_secret):

--- a/telemetry/exchange_apps.py
+++ b/telemetry/exchange_apps.py
@@ -27,6 +27,9 @@ from telemetry.styles import *
 from telemetry.calendar_telemetry import run_calendar_telemetry_pipeline
 
 class ExchangeAppsFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained customtkinter component wrapping Exchange Online Org-wide Apps UI with side-by-side columns layout."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -72,14 +75,18 @@ class ExchangeAppsFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
         for w in self.state_frame.winfo_children():
             w.destroy()
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/exchange_connectors_ui.py
+++ b/telemetry/exchange_connectors_ui.py
@@ -48,6 +48,9 @@ def fetch_exchange_connectors_data(client_id, client_secret, tenant_id) -> dict:
         return {"connectors": None, "error": str(e)}
 
 class ExchangeConnectorsFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained component for rendering Exchange Online Connectors routing logic matching ExchangeOnline UI standards."""
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
         self.semaphore = kwargs.pop("concurrency_semaphore", None)
@@ -108,7 +111,11 @@ class ExchangeConnectorsFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -121,7 +128,7 @@ class ExchangeConnectorsFrame(ctk.CTkFrame):
         elif "exchangeonlinemanagement" in error_msg.lower():
             display_msg = "ExchangeOnlineManagement PowerShell module is missing."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/exchange_online.py
+++ b/telemetry/exchange_online.py
@@ -24,6 +24,9 @@ from telemetry.exchange_connectors_ui import ExchangeConnectorsFrame
 from telemetry.mail_security import MailSecurityFrame
 
 class ExchangeOnlineFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Uber section container hosting Mailbox, Calendar, Apps, and Email Client telemetry frames vertically stacked."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -163,10 +166,11 @@ class ExchangeOnlineFrame(ctk.CTkFrame):
         ]
         if "loading" in sub_statuses or getattr(self.mail_security_view, 'loading', False):
             self.status = "loading"
-        elif "success" in sub_statuses:
-            self.status = "success"
         else:
-            self.status = "error"
+            if "success" in sub_statuses:
+                self.status = "success"
+            else:
+                self.status = "error"
         self.on_status_change()
 
     def cancel(self):

--- a/telemetry/files_telemetry.py
+++ b/telemetry/files_telemetry.py
@@ -19,6 +19,9 @@ from telemetry.styles import *
 from telemetry.sharepoint_onedrive_usage import SharePointUsageFrame, OneDriveUsageFrame
 
 class FilesTelemetryFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Uber section container hosting SharePoint and OneDrive telemetry frames vertically stacked."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):

--- a/telemetry/intune_policies.py
+++ b/telemetry/intune_policies.py
@@ -109,6 +109,9 @@ def fetch_intune_policies_data(client_id, client_secret, tenant_id) -> dict:
         return {"error": str(e)}
 
 class IntunePoliciesFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Component for rendering Intune Policies data."""
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
         self.semaphore = kwargs.pop("concurrency_semaphore", None)
@@ -167,13 +170,17 @@ class IntunePoliciesFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {error_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/m365_apps_telemetry.py
+++ b/telemetry/m365_apps_telemetry.py
@@ -19,6 +19,9 @@ from telemetry.styles import *
 from telemetry.active_users_usage import ActiveUsersUsageFrame, ActiveUsersTrendFrame, M365AppUsageFrame
 
 class M365AppsTelemetryFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Uber section container hosting Active Users Usage, Trend, and M365 App Usage frames vertically stacked."""
 
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -57,9 +60,7 @@ class M365AppsTelemetryFrame(ctk.CTkFrame):
         self.active_users_view.configure(fg_color="transparent", border_width=0)
         self.active_users_view.pack(fill="x", expand=True, pady=(0, 5))
 
-        # Divider 1
-        self.divider1 = ctk.CTkFrame(self.inner_pad, height=1, fg_color=COLOR_OUTLINE_LIGHT)
-        self.divider1.pack(fill="x", pady=10)
+
 
         # Active Users Trend Sub-frame
         self.active_users_trend_view = ActiveUsersTrendFrame(
@@ -72,9 +73,7 @@ class M365AppsTelemetryFrame(ctk.CTkFrame):
         self.active_users_trend_view.configure(fg_color="transparent", border_width=0)
         self.active_users_trend_view.pack(fill="x", expand=True, pady=(0, 5))
 
-        # Divider 2
-        self.divider2 = ctk.CTkFrame(self.inner_pad, height=1, fg_color=COLOR_OUTLINE_LIGHT)
-        self.divider2.pack(fill="x", pady=10)
+
 
         # M365 App Usage Sub-frame
         self.m365_apps_view = M365AppUsageFrame(
@@ -94,9 +93,8 @@ class M365AppsTelemetryFrame(ctk.CTkFrame):
         self.pack_forget()
         self.active_users_view.reset_view()
         self.active_users_trend_view.reset_view()
+        self.active_users_trend_view.reset_view()
         self.m365_apps_view.reset_view()
-        self.divider1.pack_forget()
-        self.divider2.pack_forget()
 
     def trigger_fetch(self, tenant, client_id, client_secret):
         """Displays container and delegates fetches to all sub-views."""
@@ -104,8 +102,6 @@ class M365AppsTelemetryFrame(ctk.CTkFrame):
         self.on_status_change()
 
         self.pack(fill="x", expand=True, pady=10)
-        self.divider1.pack(fill="x", pady=10)
-        self.divider2.pack(fill="x", pady=10)
 
         self.active_users_view.trigger_fetch(tenant, client_id, client_secret)
         self.active_users_trend_view.trigger_fetch(tenant, client_id, client_secret)
@@ -116,10 +112,11 @@ class M365AppsTelemetryFrame(ctk.CTkFrame):
         sub_statuses = [self.active_users_view.status, self.active_users_trend_view.status, self.m365_apps_view.status]
         if "loading" in sub_statuses:
             self.status = "loading"
-        elif "success" in sub_statuses:
-            self.status = "success"
         else:
-            self.status = "error"
+            if "success" in sub_statuses:
+                self.status = "success"
+            else:
+                self.status = "error"
         self.on_status_change()
 
     def cancel(self):

--- a/telemetry/m365_telemetry.py
+++ b/telemetry/m365_telemetry.py
@@ -173,7 +173,7 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
         self._create_entry(inner_pad, "Client Secret", self.lic_client_secrets, show="*")
 
         actions_frame = ctk.CTkFrame(self, fg_color="transparent")
-        actions_frame.pack(fill="x", pady=(20, 10))
+        actions_frame.pack(fill="x", pady=(20, 5))
 
         self.btn_lic_submit = ctk.CTkButton(
             actions_frame, text="Submit", width=160, height=40, corner_radius=20,
@@ -533,17 +533,17 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
                 text_color=COLOR_PRIMARY
             )
             
-            # Place in the center of the header frame if available (for Subscribed SKUs Frame)
-            if hasattr(view, "lic_header") and view.lic_header:
-                view.fetch_time_lbl.place(
-                    in_=view.lic_header,
-                    relx=0.5,
-                    rely=0.5,
-                    anchor="center"
+            # Automatically pack the timer into the header so Tkinter resolves layout clashes with buttons
+            header_target = getattr(view, "lic_header", getattr(view, "pa_header", getattr(view, "header", None)))
+            if header_target:
+                view.fetch_time_lbl.pack(
+                    in_=header_target,
+                    side="right",
+                    padx=(0, 15)
                 )
             else:
-                # Otherwise, place at the exact horizontal center of the card container, aligned vertically with the title
-                view.fetch_time_lbl.place(relx=0.5, rely=0.0, anchor="center", y=32)
+                # Place at top right of the card container inline with text (for views with no buttons)
+                view.fetch_time_lbl.place(relx=0.98, rely=0.0, anchor="ne", y=20)
 
         def display_sub_section_time(sub_sec, header_frame, elapsed):
             # Destroy old label if exists
@@ -556,21 +556,19 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
                         pass
                 view.sub_section_timer_labels[sub_sec] = None
             
-            # Create a new floating label
+            # Create a new floating label, parented to the view to avoid clipping
             lbl = ctk.CTkLabel(
-                header_frame,
+                view,
                 text=f"⏱ {elapsed:.2f}s",
                 font=ctk.CTkFont(family="Segoe UI", size=11, weight="bold"),
                 text_color=COLOR_PRIMARY
             )
             
-            # Place in the exact center of the sub-section's header frame
-            # (completely safe: title/links on the left, export button on the right)
-            lbl.place(
+            # Pack safely to the right side of the header frame (auto-avoids export buttons)
+            lbl.pack(
                 in_=header_frame,
-                relx=0.5,
-                rely=0.5,
-                anchor="center"
+                side="right",
+                padx=(0, 15)
             )
                 
             view.sub_section_timer_labels[sub_sec] = lbl

--- a/telemetry/mail_security.py
+++ b/telemetry/mail_security.py
@@ -4,9 +4,12 @@ import requests
 from telemetry.styles import *
 
 class MailSecurityFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
         self.semaphore = kwargs.pop("concurrency_semaphore", None)
-        super().__init__(master, fg_color="transparent", **kwargs)
+        super().__init__(master, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=12, **kwargs)
         self.log_msg = log_callback
         self.get_credentials = credentials_callback
         self.on_status_change_cb = status_change_callback
@@ -23,19 +26,25 @@ class MailSecurityFrame(ctk.CTkFrame):
         
         self.last_data = {}
         
-        self.grid_frame = ctk.CTkFrame(self, fg_color=COLOR_SURFACE, corner_radius=12, border_width=1, border_color=COLOR_OUTLINE_LIGHT)
+        self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
+        self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
         
-        header = ctk.CTkFrame(self.grid_frame, fg_color="transparent")
-        header.pack(fill="x", padx=15, pady=(15, 5))
-        ctk.CTkLabel(header, text="Mail Security", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(side="left")
+        self.header = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.header.pack(fill="x", pady=(0, 10))
+        ctk.CTkLabel(self.header, text="Mail Security", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(side="left")
         
-        self.loading_label = ctk.CTkLabel(self.grid_frame, text="Loading Mail Security Data...", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB)
-        self.loading_label.pack(pady=20)
+        self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_SURFACE, corner_radius=12, border_width=1, border_color=COLOR_OUTLINE_LIGHT)
+        
+        ctk.CTkLabel(self.grid_frame, text="⏳ Loading Mail Security Data...", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13)).pack(pady=(20, 5))
+        self.progress = ctk.CTkProgressBar(self.grid_frame, mode="indeterminate", width=250, fg_color=COLOR_SURFACE_VARIANT, progress_color=COLOR_PRIMARY)
+        self.progress.pack(pady=(0, 20))
 
     def trigger_fetch(self, tenant, client_id, client_secret):
         self.pack(fill="x", expand=True, pady=(0, 5))
         self.status = "loading"
         self.loading = True
+        if hasattr(self, 'progress') and self.progress:
+            self.progress.start()
         self.on_status_change()
         import threading
         threading.Thread(target=self._fetch_data, args=(tenant, client_id, client_secret), daemon=True).start()
@@ -139,10 +148,11 @@ class MailSecurityFrame(ctk.CTkFrame):
         self.loading = True
         self.grid_frame.pack_forget()
         for widget in self.grid_frame.winfo_children():
-            if widget != self.grid_frame.winfo_children()[0]: # Keep header
-                widget.destroy()
-        self.loading_label = ctk.CTkLabel(self.grid_frame, text="Loading Mail Security Data...", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB)
-        self.loading_label.pack(pady=20)
+            widget.destroy()
+        self.loading_label = ctk.CTkLabel(self.grid_frame, text="⏳ Loading Mail Security Data...", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        self.progress = ctk.CTkProgressBar(self.grid_frame, mode="indeterminate", width=250, fg_color=COLOR_SURFACE_VARIANT, progress_color=COLOR_PRIMARY)
+        self.progress.pack(pady=(0, 20))
 
     def cancel(self):
         self.status = None
@@ -151,10 +161,17 @@ class MailSecurityFrame(ctk.CTkFrame):
 
     def on_status_change(self):
         try:
+            if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+                self.loading_label.destroy()
+            if hasattr(self, 'progress') and self.progress.winfo_exists():
+                self.progress.stop()
+                self.progress.destroy()
+        except:
+            pass
+        try:
             self.loading_label.destroy()
         except:
             pass
-            
         if self.loading:
             return
             

--- a/telemetry/mailbox_usage.py
+++ b/telemetry/mailbox_usage.py
@@ -224,7 +224,10 @@ class MailboxUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=(20, 5))
+        self.progress = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        self.progress.pack(pady=(0, 20))
+        self.progress.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):

--- a/telemetry/power_automate.py
+++ b/telemetry/power_automate.py
@@ -361,6 +361,9 @@ class PowerAutomateScanner:
 # =================================================================================
 
 class PowerAutomateUsageFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained component wrapping Power Automate UI and export controls."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -381,12 +384,12 @@ class PowerAutomateUsageFrame(ctk.CTkFrame):
         self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
         self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
         
-        pa_header = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
-        pa_header.pack(fill="x", pady=(0, 10))
-        ctk.CTkLabel(pa_header, text="Power Automate", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(side="left")
+        self.pa_header = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.pa_header.pack(fill="x", pady=(0, 10))
+        ctk.CTkLabel(self.pa_header, text="Power Automate", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(side="left")
         
         self.btn_export_pa = ctk.CTkButton(
-            pa_header, text="Export Complex Flows", width=160, height=32, corner_radius=16,
+            self.pa_header, text="Export Complex Flows", width=160, height=32, corner_radius=16,
             font=FONT_BODY_BOLD, fg_color="transparent", border_width=1, border_color=COLOR_OUTLINE,
             text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER,
             command=self.export_complex_flows, state="disabled"
@@ -439,7 +442,11 @@ class PowerAutomateUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -450,7 +457,7 @@ class PowerAutomateUsageFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Management Link / Flow read permissions required."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 

--- a/telemetry/sharepoint_onedrive_usage.py
+++ b/telemetry/sharepoint_onedrive_usage.py
@@ -258,6 +258,9 @@ def run_onedrive_pipeline(client_id, client_secret, tenant_id) -> dict:
 # =================================================================================
 
 class SharePointUsageFrame(ctk.CTkFrame):
+    def update_loading_text(self, text_msg):
+        if hasattr(self, 'loading_label') and self.loading_label.winfo_exists():
+            self.loading_label.configure(text=f"⏳ {text_msg}")
     """Self-contained customtkinter component wrapping SharePoint Telemetry UI."""
     
     def __init__(self, master, log_callback, credentials_callback, status_change_callback, **kwargs):
@@ -298,7 +301,11 @@ class SharePointUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -309,7 +316,7 @@ class SharePointUsageFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Microsoft Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -324,7 +331,7 @@ class SharePointUsageFrame(ctk.CTkFrame):
         self.status = "loading"
         self.on_status_change()
         
-        self.pack(fill="x", expand=True, pady=(20, 10))
+        self.pack(fill="x", expand=True, pady=(20, 5))
         self.grid_frame.pack_forget()
         
         self._set_state_loading("Downloading and parsing SharePoint Site Usage reports...")
@@ -437,7 +444,11 @@ class OneDriveUsageFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        self.loading_label = __import__("customtkinter").CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=__import__("customtkinter").CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):
@@ -448,7 +459,7 @@ class OneDriveUsageFrame(ctk.CTkFrame):
         if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
             display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Microsoft Entra ID."
 
-        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 10))
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
         ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
         self.state_frame.pack(fill="x", expand=True)
 
@@ -463,7 +474,7 @@ class OneDriveUsageFrame(ctk.CTkFrame):
         self.status = "loading"
         self.on_status_change()
         
-        self.pack(fill="x", expand=True, pady=(20, 10))
+        self.pack(fill="x", expand=True, pady=(20, 5))
         self.grid_frame.pack_forget()
         
         self._set_state_loading("Downloading and parsing OneDrive reports...")

--- a/telemetry/subscribed_skus.py
+++ b/telemetry/subscribed_skus.py
@@ -106,7 +106,10 @@ class SubscribedSKUsFrame(ctk.CTkFrame):
     def _set_state_loading(self, msg="Loading..."):
         for w in self.state_frame.winfo_children():
             w.destroy()
-        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=20)
+        ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color=COLOR_TEXT_SUB, font=FONT_BODY_MEDIUM).pack(pady=(20, 5))
+        self.progress = __import__("customtkinter").CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        self.progress.pack(pady=(0, 20))
+        self.progress.start()
         self.state_frame.pack(fill="x", expand=True)
 
     def _set_state_error(self, error_msg):


### PR DESCRIPTION
Fixes Mail Security component layout to properly align with other cards using inner_pad. Strips out redundant container divider lines from M365 Apps tab. Standardizes unified linear progress bars coupled with single static loading messages across all telemetry components.