### PR TITLE
feat: Add MsTeams Overview Telemetry Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,11 @@ The Usage and Adoption tab scans the following 10 functional modules of a Micros
       <td>Cloud Flows and Desktop Flows configurations, listing active/inactive flows and checking for complex connectors or premium triggers.</td>
       <td>Power Platform Admin / CRM Dataverse API requests:<br>• Environments: <code>GET https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments</code><br>• Cloud Flows: <code>GET https://service.flow.microsoft.com/providers/Microsoft.ProcessSimple/environments/{env}/flows</code><br>• Desktop Flows: CRM Dataverse <code>GET /api/data/v9.0/workflows</code> (Category 6)</td>
     </tr>
+    <tr>
+      <td><b>11. Microsoft Teams Overview</b></td>
+      <td>• <b>Teams Activity</b>: Active users, guests, meetings organized, and channel messages over the last 180 days across all teams.</td>
+      <td>Graph Reports API:<br>• Teams Activity: <code>GET /reports/getTeamsTeamActivityDetail(period='D180')</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/core/graph/files/msteams_overview.py
+++ b/core/graph/files/msteams_overview.py
@@ -1,0 +1,40 @@
+import os
+import logging
+from core.graph.client import GraphClient
+from core.graph.reports import ReportsService
+
+logger = logging.getLogger(__name__)
+
+def run_msteams_pipeline(client_id, client_secret, tenant_id) -> str:
+    """Pipeline specifically for MsTeams Overview telemetry data collection."""
+    logger.info("Starting MsTeams Overview Telemetry Pipeline...")
+    
+    client = GraphClient(
+        tenant_id=tenant_id,
+        client_ids=client_id,
+        client_secrets=client_secret,
+        concurrency=2,
+        retries=5,
+        backoff=2
+    )
+    client.authenticate()
+    service = ReportsService(client)
+    
+    script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
+    telemetry_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(script_dir))), "telemetry")
+    reports_dir = os.path.join(telemetry_dir, "reports", f"{tenant_id}_{client_id}")
+    
+    output_filename = "msteams_activity.csv"
+    temp_filename = output_filename + ".tmp"
+    url = "https://graph.microsoft.com/v1.0/reports/getTeamsTeamActivityDetail(period='D180')"
+    
+    service.download_report(url, temp_filename, reports_dir)
+    
+    final_path = os.path.join(reports_dir, output_filename)
+    tmp_path = os.path.join(reports_dir, temp_filename)
+    if os.path.exists(tmp_path):
+        os.replace(tmp_path, final_path)
+    
+    logger.info("MsTeams Overview Telemetry Pipeline completed successfully.")
+    client.close()
+    return final_path

--- a/telemetry/files/msteams_overview.py
+++ b/telemetry/files/msteams_overview.py
@@ -1,0 +1,229 @@
+import os
+import logging
+import threading
+import sqlite3
+import asyncio
+import customtkinter as ctk
+
+from core.graph.files.msteams_overview import run_msteams_pipeline
+from core.graph.db import import_csv_to_sqlite
+from telemetry.styles import *
+
+logger = logging.getLogger("M365TelemetryAsyncLogger.MsTeamsOverviewUI")
+
+class MsTeamsOverviewFrame(ctk.CTkFrame):
+    def __init__(self, master, log_callback, credentials_callback, status_change_callback, semaphore=None, **kwargs):
+        self.semaphore = semaphore
+        super().__init__(master, fg_color=COLOR_SURFACE, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=12, **kwargs)
+        self.log_msg = log_callback
+        self.get_credentials = credentials_callback
+        self.on_status_change = status_change_callback
+        
+        self.status = None
+        self.is_cancelled = False
+        self.current_request_id = 0
+        self.csv_path = None
+        
+        self.build_ui()
+
+    def build_ui(self):
+        self.pack(fill="x", expand=True, pady=10)
+        
+        self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
+        self.inner_pad.pack(fill="both", expand=True, padx=20, pady=20)
+        
+        self.header = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.header.pack(fill="x", pady=(0, 10))
+        ctk.CTkLabel(self.header, text="Microsoft Teams Overview", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(side="left")
+        self.reload_btn = ctk.CTkButton(
+            self.header, 
+            state="disabled", text="↻ Reload", 
+            width=80, 
+            height=24,
+            font=ctk.CTkFont(family="Segoe UI", size=12),
+            fg_color="transparent", 
+            border_width=1, 
+            text_color="#2563EB", 
+            hover_color="#DBEAFE",
+            command=self._retry_fetch
+        )
+        self.reload_btn.pack(side="right")
+        
+        self.state_frame = ctk.CTkFrame(self.inner_pad, fg_color="transparent")
+        self.grid_frame = ctk.CTkFrame(self.inner_pad, fg_color=COLOR_OUTLINE_LIGHT, border_color=COLOR_OUTLINE_LIGHT, border_width=1, corner_radius=8)
+        
+        self.reset_view()
+
+    def reset_view(self):
+        self.pack_forget()
+        self.state_frame.pack_forget()
+        self.grid_frame.pack_forget()
+        
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+
+    def _set_state_loading(self, msg="Loading..."):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+        self.loading_label = ctk.CTkLabel(self.state_frame, text=f"⏳ {msg}", text_color="#6b7280", font=ctk.CTkFont(family="Segoe UI", size=13))
+        self.loading_label.pack(pady=(20, 5))
+        pb = ctk.CTkProgressBar(self.state_frame, mode="indeterminate", width=250, fg_color="#F3F4F6", progress_color="#2563EB")
+        pb.pack(pady=(0, 20))
+        pb.start()
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _set_state_error(self, error_msg):
+        for w in self.state_frame.winfo_children():
+            w.destroy()
+
+        display_msg = error_msg
+        if "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower() or "forbidden" in error_msg.lower():
+            display_msg = "Reports telemetry permission required.\nPlease grant the 'Reports.Read.All' application permission to your App Registration in Microsoft Entra ID."
+
+        ctk.CTkLabel(self.state_frame, text=f"✖ {display_msg}", text_color=COLOR_ERROR, font=FONT_BODY_MEDIUM, justify="center").pack(pady=(20, 5))
+        ctk.CTkButton(self.state_frame, text="Try Again", command=self._retry_fetch, width=120, fg_color="transparent", border_width=1, text_color=COLOR_PRIMARY, hover_color=COLOR_SECONDARY_HOVER).pack(pady=(0, 20))
+        self.state_frame.pack(fill="x", expand=True)
+
+    def _retry_fetch(self):
+        if hasattr(self, 'reload_btn') and self.reload_btn.winfo_exists():
+            self.reload_btn.configure(state="disabled")
+        tenant, clients, secrets = self.get_credentials()
+        if tenant:
+            self.trigger_fetch(tenant, clients[0], secrets[0])
+
+    def trigger_fetch(self, tenant, client_id, client_secret):
+        logger.info("MsTeams Overview trigger_fetch called.")
+        self.status = "loading"
+        self.is_cancelled = False
+        self.on_status_change()
+        
+        self.pack(fill="x", expand=True, pady=(20, 5))
+        self.grid_frame.pack_forget()
+        
+        self._set_state_loading("Scanning MsTeams details...")
+        
+        threading.Thread(
+            target=self._execute_worker,
+            args=(tenant, client_id, client_secret, self.current_request_id),
+            daemon=True
+        ).start()
+
+    def _execute_worker(self, tenant: str, client_id: str, client_secret: str, request_id: int):
+        if self.semaphore:
+            self.semaphore.acquire()
+        try:
+            if self.is_cancelled or request_id != self.current_request_id: return
+            
+            self.csv_path = run_msteams_pipeline(client_id, client_secret, tenant)
+            
+            if self.is_cancelled or request_id != self.current_request_id: return
+            
+            db_path = os.path.join(os.path.dirname(self.csv_path), "telemetry_cache.db")
+            asyncio.run(import_csv_to_sqlite(self.csv_path, db_path, "msteams_activity"))
+            
+            if self.is_cancelled or request_id != self.current_request_id: return
+            
+            self.status = "success"
+            self.after(0, self._render_success, request_id)
+        except Exception as e:
+            logger.error(f"Error fetching feature telemetry: {e}", exc_info=True)
+            self.status = "error"
+            self.after(0, self._render_error, str(e), request_id)
+        finally:
+            if self.semaphore:
+                self.semaphore.release()
+            self.after(0, self.on_status_change)
+
+    def _load_metrics_from_sqlite(self):
+        if not self.csv_path or not os.path.exists(self.csv_path): return {}
+        db_path = os.path.join(os.path.dirname(self.csv_path), "telemetry_cache.db")
+        if not os.path.exists(db_path): return {}
+
+        conn = sqlite3.connect(db_path)
+        metrics = {}
+        try:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            
+            cursor.execute("SELECT COUNT(*) FROM msteams_activity WHERE Team_Name IS NOT NULL AND Team_Name != ''")
+            row = cursor.fetchone()
+            metrics["total_teams"] = row[0] if row else 0
+
+            cursor.execute("SELECT SUM(Active_Users), SUM(Guests), SUM(Active_Channels), SUM(Channel_Messages), SUM(Meetings_Organized) FROM msteams_activity WHERE Team_Name IS NOT NULL AND Team_Name != ''")
+            row = cursor.fetchone()
+            metrics["active_users"] = int(row[0] or 0) if row else 0
+            metrics["guests"] = int(row[1] or 0) if row else 0
+            metrics["active_channels"] = int(row[2] or 0) if row else 0
+            metrics["channel_messages"] = int(row[3] or 0) if row else 0
+            metrics["meetings_organized"] = int(row[4] or 0) if row else 0
+            
+            return metrics
+        except Exception as e:
+            logger.error(f"Error reading SQLite: {e}")
+            return {}
+        finally:
+            conn.close()
+
+    def _render_success(self, request_id):
+        if self.is_cancelled or request_id != self.current_request_id: return
+        if hasattr(self, 'reload_btn') and self.reload_btn.winfo_exists():
+            self.reload_btn.configure(state="normal")
+            
+        self.state_frame.pack_forget()
+        self._update_grid()
+        self.grid_frame.pack(fill="x", expand=True)
+        
+    def _render_error(self, err_msg, request_id):
+        if self.is_cancelled or request_id != self.current_request_id: return
+        logger.warning(f"MsTeams Overview fetch failed: {err_msg}")
+        if hasattr(self, 'reload_btn') and self.reload_btn.winfo_exists():
+            self.reload_btn.configure(state="normal")
+        self._set_state_error(err_msg)
+
+    def _update_grid(self):
+        for w in self.grid_frame.winfo_children():
+            w.destroy()
+            
+        metrics = self._load_metrics_from_sqlite()
+        
+        self.grid_frame.grid_columnconfigure(0, weight=3)
+        self.grid_frame.grid_columnconfigure(1, weight=2)
+        
+        headers = ["MsTeams Metric Description", "Value / Measurement"]
+        for col_idx, head_text in enumerate(headers):
+            cell = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_TONAL_BG, corner_radius=0)
+            cell.grid(row=0, column=col_idx, sticky="nsew", padx=0, pady=(0, 1))
+            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+            
+        if not metrics:
+            c0 = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_SURFACE, corner_radius=0)
+            c0.grid(row=1, column=0, columnspan=len(headers), sticky="nsew", padx=0, pady=(0, 1))
+            ctk.CTkLabel(c0, text="No activity data found.", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6)
+            return
+            
+        users = metrics.get('active_users', 0)
+        channels = metrics.get('active_channels', 0)
+        avg_users_per_channel = f"{(users / channels):.1f}" if channels > 0 else "0"
+            
+        rows_data = [
+            ("Total Teams Count", f"{metrics.get('total_teams', 0):,} Teams"),
+            ("Total Active Channels (180 days)", f"{channels:,} Channels"),
+            ("Total Channel Messages", f"{metrics.get('channel_messages', 0):,} Messages"),
+            ("Total Active Users(180 days)", f"{users:,} Users"),
+            ("Average Users per Channel", avg_users_per_channel),
+            ("Total Meetings Organized", f"{metrics.get('meetings_organized', 0):,} Meetings"),
+            ("Total Guests", f"{metrics.get('guests', 0):,} Guests")
+        ]
+        
+        for r_idx, (metric_name, val) in enumerate(rows_data, start=1):
+            bg_style = COLOR_SURFACE if r_idx % 2 == 0 else COLOR_SURFACE_VARIANT
+            
+            c0 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c0.grid(row=r_idx, column=0, sticky="nsew", padx=0, pady=(0, 1))
+            ctk.CTkLabel(c0, text=metric_name, font=FONT_BODY_BOLD, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")
+
+            c1 = ctk.CTkFrame(self.grid_frame, fg_color=bg_style, corner_radius=0)
+            c1.grid(row=r_idx, column=1, sticky="nsew", padx=0, pady=(0, 1))
+            ctk.CTkLabel(c1, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN).pack(padx=10, pady=6, anchor="w")

--- a/telemetry/m365_telemetry.py
+++ b/telemetry/m365_telemetry.py
@@ -39,6 +39,7 @@ from telemetry.power_automate import PowerAutomateUsageFrame
 
 
 # Import existing modular views
+from telemetry.files.msteams_overview import MsTeamsOverviewFrame
 from telemetry.files import FilesTelemetryFrame
 from telemetry.devices_apps_telemetry import DevicesAppsTelemetryFrame
 from telemetry.email_client_support import EmailClientSupportFrame
@@ -190,7 +191,7 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             [self.directory_view],
             [self.m365_apps_view],
             [self.exchange_online_view],
-            [self.files_view],
+            [self.files_view, self.msteams_overview_view],
             [self.devices_apps_view, self.intune_policies_view],
             [self.network_security_view],
             [self.security_gov_view],
@@ -309,13 +310,13 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             concurrency_semaphore=self.telemetry_semaphore
         )
 
-        # 5c. Files (SharePoint & OneDrive) Section
-        self.files_view = FilesTelemetryFrame(
+        # 5d. MsTeams Overview Section
+        self.msteams_overview_view = MsTeamsOverviewFrame(
             master=self,
             log_callback=self.log_msg,
             credentials_callback=self._get_credentials,
             status_change_callback=self._check_all_done,
-            concurrency_semaphore=self.telemetry_semaphore
+            semaphore=self.telemetry_semaphore
         )
 
         # 5e. Network Security Section
@@ -357,18 +358,6 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             concurrency_semaphore=self.telemetry_semaphore
         )
 
-        self.batches = [
-            [self.subscribed_skus_view],
-            [self.devices_apps_view],
-            [self.directory_view],
-            [self.m365_apps_view],
-            [self.exchange_online_view],
-            [self.files_view],
-            [self.intune_policies_view],
-            [self.security_gov_view],
-            [self.power_automate_view]
-        ]
-        self.current_batch_index = 0
 
         # Bind mouse wheel globally to scroll this tab when hovered
         self.bind_all("<MouseWheel>", self._handle_global_mousewheel, add="+")
@@ -388,6 +377,7 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             self.m365_apps_view,
             self.exchange_online_view,
             self.files_view,
+            self.msteams_overview_view,
             self.devices_apps_view,
             self.network_security_view,
             self.security_gov_view,
@@ -549,6 +539,7 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             self.exchange_online_view.pst_files_view,
             self.files_view.sharepoint_view,
             self.files_view.onedrive_view,
+            self.msteams_overview_view,
             self.network_security_view.filtering_view,
             self.network_security_view.ca_view,
             self.network_security_view.fw_view,
@@ -589,6 +580,7 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             "SharePointUsageFrame": "SharePoint Online Sites & Files Summary",
             "SharePointDataTypesFrame": "SharePoint Data Types (Tenant Wide)",
             "OneDriveUsageFrame": "OneDrive for Business Personal Accounts Summary",
+            "MsTeamsOverviewFrame": "Microsoft Teams Overview (180 Days)",
             "FilteringPoliciesSubFrame": "Filtering Policies",
             "ConditionalAccessSubFrame": "Conditional Access Policies",
             "FirewallSubFrame": "Firewall and Proxy Configurations",
@@ -1038,7 +1030,8 @@ class M365TelemetryTab(ctk.CTkScrollableFrame):
             "service_principals_sso": getattr(self.security_gov_view.sso_frame, "last_data", []),
             "conditional_access": getattr(self.security_gov_view.auth_frame, "last_data", []),
             "ediscovery_cases": load_csv("ediscovery_cases.csv"),
-            "power_automate": getattr(self.power_automate_view, "last_results", {})
+            "power_automate": getattr(self.power_automate_view, "last_results", {}),
+            "msteams_activity": load_csv("msteams_activity.csv")
         }
 
     def _get_email_clients_pdf_mapped(self) -> dict:

--- a/telemetry/pdf_report.py
+++ b/telemetry/pdf_report.py
@@ -1133,6 +1133,47 @@ def generate_pdf_report(data: dict, filepath: str):
         story.append(sp_dt_table)
         story.append(Spacer(1, 15))
 
+    # 3.2b Microsoft Teams Overview
+    story.append(Paragraph("Microsoft Teams Overview", h2_style))
+    story.append(Paragraph("A summary of Microsoft Teams activity, including active users, guests, and meetings organized over the last 180 days.", body_style))
+    story.append(Spacer(1, 8))
+    
+    msteams_data = data.get("msteams_activity", [])
+    if not msteams_data:
+        story.append(Paragraph("No Microsoft Teams activity data was available.", ParagraphStyle('ErrTxt', parent=body_style, textColor=colors.HexColor("#DC2626"))))
+    else:
+        teams_table_data = [[
+            Paragraph("Team Name", table_cell_header),
+            Paragraph("Last Activity", table_cell_header),
+            Paragraph("Active Users", table_cell_header),
+            Paragraph("Guests", table_cell_header),
+            Paragraph("Meetings", table_cell_header),
+            Paragraph("Messages", table_cell_header)
+        ]]
+        
+        for row in msteams_data[:20]:
+            teams_table_data.append([
+                Paragraph(row.get("Team Name", "-"), table_cell_bold),
+                Paragraph(row.get("Last Activity Date", "-"), table_cell_style),
+                Paragraph(row.get("Active Users", "0"), table_cell_style),
+                Paragraph(row.get("Guests", "0"), table_cell_style),
+                Paragraph(row.get("Meetings Organized", "0"), table_cell_style),
+                Paragraph(row.get("Channel Messages", "0"), table_cell_style)
+            ])
+            
+        teams_table = Table(teams_table_data, colWidths=[120, 70, 70, 50, 70, 70])
+        teams_table.setStyle(TableStyle([
+            ('BACKGROUND', (0, 0), (-1, 0), primary_color),
+            ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+            ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
+            ('TOPPADDING', (0, 0), (-1, -1), 5),
+            ('BOTTOMPADDING', (0, 0), (-1, -1), 5),
+            ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.white, colors.HexColor("#F8FAFC")]),
+            ('GRID', (0, 0), (-1, -1), 0.5, outline_color),
+        ]))
+        story.append(teams_table)
+        story.append(Spacer(1, 15))
+
     # 3.3 Microsoft Entra Data
     story.append(Paragraph("Microsoft Entra Data", h2_style))
     story.append(Paragraph("This section outlines application sign-in metrics and authentication methods configuration summaries.", body_style))


### PR DESCRIPTION
## Description
This PR introduces the new Microsoft Teams Overview telemetry section to the M365 Deal Assistant.

### Features
- Queries the Microsoft Graph API `getTeamsTeamActivityDetail(period='D180')` endpoint.
- Caches the MsTeams activity report locally in SQLite.
- Integrates a new `MsTeamsOverviewFrame` into the CustomTkinter UI.
- Redesigns the UI to present high-level, aggregated metrics rather than overwhelming the user with a raw paginated list.

### Metrics Computed:
- Total Teams Count
- Total Active Channels
- Total Channel Messages
- Total Active Users
- Average Users per Channel
- Total Meetings Organized
- Total Guests

### Fixes included:
- Fixed a silent failure where the UI wouldn't render the module due to a duplicate `batches` list in `m365_telemetry.py`.
- Fixed an SQLite schema issue where column names containing spaces broke the UI query.