### PR TITLE
feat: Integrate Data at Rest Encryption detection into Mail Security

### DIFF
--- a/core/powershell/encryption.py
+++ b/core/powershell/encryption.py
@@ -12,17 +12,13 @@ def get_encryption_policies(client: PowerShellClient) -> dict:
     """
     logger.info("Starting M365 Data Encryption Policy fetch via PowerShell...")
     try:
-        # Load the thumbprint using the existing cert_auth module
-        _, thumbprint = load_certificate(
-            client_secret=client.cert_password,
-            tenant_id=client.cert_tenant_id,
-            client_id=client.client_id
-        )
+        cert_path = client.locate_certificate()
 
         args = [
             "-TenantId", client.tenant_id,
             "-AppId", client.client_id,
-            "-CertificateThumbprint", thumbprint
+            "-CertificateFilePath", cert_path,
+            "-CertificatePassword", client.cert_password
         ]
 
         stdout = client.execute_script("scripts/export_encryption_policies.ps1", args)

--- a/core/powershell/encryption.py
+++ b/core/powershell/encryption.py
@@ -1,0 +1,49 @@
+import json
+import logging
+from core.powershell.client import PowerShellClient
+from core.cert_auth import load_certificate
+
+logger = logging.getLogger(__name__)
+
+def get_encryption_policies(client: PowerShellClient) -> dict:
+    """
+    Executes the export_encryption_policies.ps1 script using the PowerShellClient.
+    Returns a dictionary with 'm365_policies' and 'exchange_deps'.
+    """
+    logger.info("Starting M365 Data Encryption Policy fetch via PowerShell...")
+    try:
+        # Load the thumbprint using the existing cert_auth module
+        _, thumbprint = load_certificate(
+            client_secret=client.cert_password,
+            tenant_id=client.cert_tenant_id,
+            client_id=client.client_id
+        )
+
+        args = [
+            "-TenantId", client.tenant_id,
+            "-AppId", client.client_id,
+            "-CertificateThumbprint", thumbprint
+        ]
+
+        stdout = client.execute_script("scripts/export_encryption_policies.ps1", args)
+        
+        # Parse the JSON output from PowerShell
+        if stdout and stdout.strip():
+            # Find where the JSON starts in case of warnings
+            try:
+                json_start = stdout.find('{')
+                if json_start != -1:
+                    json_str = stdout[json_start:]
+                    return json.loads(json_str)
+                else:
+                    logger.warning("No JSON object found in PowerShell output.")
+                    return {"m365_policies": [], "exchange_deps": []}
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to decode JSON from PowerShell: {e}\nOutput: {stdout}")
+                raise RuntimeError("Failed to parse encryption policies from Exchange Online.")
+        else:
+            return {"m365_policies": [], "exchange_deps": []}
+
+    except Exception as e:
+        logger.error(f"Error fetching encryption policies: {e}", exc_info=True)
+        raise

--- a/core/powershell/encryption.py
+++ b/core/powershell/encryption.py
@@ -15,7 +15,7 @@ def get_encryption_policies(client: PowerShellClient) -> dict:
         cert_path = client.locate_certificate()
 
         args = [
-            "-TenantId", client.tenant_id,
+            "-Organization", client.tenant_id,
             "-AppId", client.client_id,
             "-CertificateFilePath", cert_path,
             "-CertificatePassword", client.cert_password

--- a/core/powershell/scripts/export_encryption_policies.ps1
+++ b/core/powershell/scripts/export_encryption_policies.ps1
@@ -1,7 +1,8 @@
 param (
     [Parameter(Mandatory=$true)][string]$TenantId,
     [Parameter(Mandatory=$true)][string]$AppId,
-    [Parameter(Mandatory=$true)][string]$CertificateThumbprint
+    [Parameter(Mandatory=$true)][string]$CertificateFilePath,
+    [Parameter(Mandatory=$true)][string]$CertificatePassword
 )
 
 # Force TLS 1.2
@@ -10,8 +11,10 @@ param (
 $ErrorActionPreference = "Stop"
 
 try {
+    # Convert password to SecureString for macOS/Linux compatibility
+    $secPass = ConvertTo-SecureString $CertificatePassword -AsPlainText -Force
     # Connect using Certificate-based App-Only Authentication
-    Connect-ExchangeOnline -AppID $AppId -Organization $TenantId -CertificateThumbprint $CertificateThumbprint -ShowBanner:$false -ErrorAction Stop
+    Connect-ExchangeOnline -AppID $AppId -Organization $TenantId -CertificateFilePath $CertificateFilePath -CertificatePassword $secPass -ShowBanner:$false -ErrorAction Stop
 
     $result = @{
         "m365_policies" = @()

--- a/core/powershell/scripts/export_encryption_policies.ps1
+++ b/core/powershell/scripts/export_encryption_policies.ps1
@@ -1,5 +1,5 @@
 param (
-    [Parameter(Mandatory=$true)][string]$TenantId,
+    [Parameter(Mandatory=$true)][string]$Organization,
     [Parameter(Mandatory=$true)][string]$AppId,
     [Parameter(Mandatory=$true)][string]$CertificateFilePath,
     [Parameter(Mandatory=$true)][string]$CertificatePassword
@@ -10,11 +10,17 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+    throw "ExchangeOnlineManagement PowerShell module is not installed."
+}
+
+Import-Module ExchangeOnlineManagement
+
 try {
     # Convert password to SecureString for macOS/Linux compatibility
     $secPass = ConvertTo-SecureString $CertificatePassword -AsPlainText -Force
     # Connect using Certificate-based App-Only Authentication
-    Connect-ExchangeOnline -AppID $AppId -Organization $TenantId -CertificateFilePath $CertificateFilePath -CertificatePassword $secPass -ShowBanner:$false -ErrorAction Stop
+    Connect-ExchangeOnline -AppID $AppId -Organization $Organization -CertificateFilePath $CertificateFilePath -CertificatePassword $secPass -ShowBanner:$false -ErrorAction Stop
 
     $result = @{
         "m365_policies" = @()

--- a/core/powershell/scripts/export_encryption_policies.ps1
+++ b/core/powershell/scripts/export_encryption_policies.ps1
@@ -1,0 +1,58 @@
+param (
+    [Parameter(Mandatory=$true)][string]$TenantId,
+    [Parameter(Mandatory=$true)][string]$AppId,
+    [Parameter(Mandatory=$true)][string]$CertificateThumbprint
+)
+
+# Force TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$ErrorActionPreference = "Stop"
+
+try {
+    # Connect using Certificate-based App-Only Authentication
+    Connect-ExchangeOnline -AppID $AppId -Organization $TenantId -CertificateThumbprint $CertificateThumbprint -ShowBanner:$false -ErrorAction Stop
+
+    $result = @{
+        "m365_policies" = @()
+        "exchange_deps" = @()
+    }
+
+    # Fetch M365 Data at Rest Encryption Policies (Customer Key multi-workload)
+    try {
+        $m365Policies = Get-M365DataAtRestEncryptionPolicy -ErrorAction SilentlyContinue
+        if ($m365Policies) {
+            foreach ($pol in $m365Policies) {
+                $result["m365_policies"] += @{
+                    "Name" = $pol.Name
+                    "Description" = $pol.Description
+                }
+            }
+        }
+    } catch {
+        # Catch unsupported or missing permissions specifically for this cmdlet
+    }
+
+    # Fetch legacy Exchange Data Encryption Policies (DEPs)
+    try {
+        $deps = Get-DataEncryptionPolicy -ErrorAction SilentlyContinue
+        if ($deps) {
+            foreach ($dep in $deps) {
+                $result["exchange_deps"] += @{
+                    "Name" = $dep.Name
+                    "Description" = $dep.Description
+                }
+            }
+        }
+    } catch {
+        # Catch unsupported or missing permissions specifically for this cmdlet
+    }
+
+    $result | ConvertTo-Json -Depth 5 -Compress
+
+} catch {
+    Write-Error $_.Exception.Message
+    exit 1
+} finally {
+    Disconnect-ExchangeOnline -Confirm:$false -ErrorAction SilentlyContinue
+}

--- a/telemetry/exchange/mail_security.py
+++ b/telemetry/exchange/mail_security.py
@@ -98,7 +98,35 @@ class MailSecurityFrame(ctk.CTkFrame):
                 # Fetch encryption policies
                 def fetch_encryption():
                     try:
-                        ps_client = PowerShellClient(tenant, c_id, c_secret)
+                        from core.graph.client import GraphClient
+                        from core.graph.directory import DirectoryService
+                        
+                        tenant_domain = tenant
+                        client = None
+                        try:
+                            client = GraphClient(
+                                tenant_id=tenant,
+                                client_ids=c_id,
+                                client_secrets=c_secret,
+                                concurrency=1,
+                                retries=3,
+                                backoff=2
+                            )
+                            client.authenticate()
+                            dir_svc = DirectoryService(client)
+                            tenant_domain = dir_svc.get_tenant_primary_domain()
+                        except Exception as e:
+                            usage_logger.warning(f"Could not retrieve tenant domain via Graph. Falling back to Tenant ID Guid: {e}")
+                        finally:
+                            if client:
+                                client.close()
+
+                        ps_client = PowerShellClient(
+                            tenant_id=tenant_domain,
+                            client_id=c_id,
+                            client_secret=c_secret,
+                            cert_tenant_id=tenant
+                        )
                         return get_encryption_policies(ps_client)
                     except Exception as e:
                         usage_logger.warning(f"Failed to fetch encryption policies: {e}")

--- a/telemetry/exchange/mail_security.py
+++ b/telemetry/exchange/mail_security.py
@@ -18,9 +18,12 @@ import os
 import csv
 import logging
 import threading
+import concurrent.futures
 import customtkinter as ctk
 
 from core.graph.exchange.mail_security import run_mail_security_pipeline
+from core.powershell.client import PowerShellClient
+from core.powershell.encryption import get_encryption_policies
 from telemetry.styles import *
 
 usage_logger = logging.getLogger("M365TelemetryAsyncLogger.MailSecurityUI")
@@ -49,6 +52,7 @@ class MailSecurityFrame(ctk.CTkFrame):
         self.total_defender_users = 0
         self.defender_skus = []
         
+        self.encryption_data = {"m365_policies": [], "exchange_deps": [], "error": None}
         self.last_data = {}
         
         self.inner_pad = ctk.CTkFrame(self, fg_color="transparent")
@@ -88,7 +92,22 @@ class MailSecurityFrame(ctk.CTkFrame):
         if self.semaphore:
             self.semaphore.acquire()
         try:
-            result_data = run_mail_security_pipeline(c_id, c_secret, tenant)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                skus_future = executor.submit(run_mail_security_pipeline, c_id, c_secret, tenant)
+                
+                # Fetch encryption policies
+                def fetch_encryption():
+                    try:
+                        ps_client = PowerShellClient(tenant, c_id, c_secret)
+                        return get_encryption_policies(ps_client)
+                    except Exception as e:
+                        usage_logger.warning(f"Failed to fetch encryption policies: {e}")
+                        return {"m365_policies": [], "exchange_deps": [], "error": str(e)}
+                
+                enc_future = executor.submit(fetch_encryption)
+                
+                result_data = skus_future.result()
+                self.encryption_data = enc_future.result()
             
             self.defender_skus = result_data["defender"]["skus"]
             self.total_defender_users = result_data["defender"]["users"]
@@ -206,5 +225,43 @@ class MailSecurityFrame(ctk.CTkFrame):
                     c.grid(row=r_idx, column=c_idx, sticky="nsew", padx=0, pady=(0, 1))
                     ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=450).pack(padx=10, pady=12, anchor="nw")
                     
+        # --- ENCRYPTION UI ---
+        ctk.CTkLabel(self.grid_frame, text="Data at Rest Encryption", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(fill="x", padx=15, pady=(20, 5))
+        
+        enc_grid = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_SURFACE, corner_radius=0)
+        enc_grid.pack(fill="x", padx=10, pady=(0, 10))
+        
+        enc_headers = ["Encryption Posture", "Tenant-Level Policies (M365)", "Mailbox Policies (Exchange DEPs)"]
+        for i in range(3):
+            enc_grid.grid_columnconfigure(i, weight=1)
+            
+        for col_idx, head_text in enumerate(enc_headers):
+            cell = ctk.CTkFrame(enc_grid, fg_color=COLOR_TONAL_BG, corner_radius=0)
+            cell.grid(row=0, column=col_idx, sticky="nsew", padx=0, pady=(0, 1))
+            ctk.CTkLabel(cell, text=head_text, font=FONT_BODY_BOLD, text_color=COLOR_TONAL_TEXT).pack(padx=10, pady=8, anchor="w")
+
+        if self.encryption_data.get("error"):
+            # Error fetching policies (e.g., missing permissions or script error)
+            c = ctk.CTkFrame(enc_grid, fg_color=COLOR_SURFACE, corner_radius=0)
+            c.grid(row=1, column=0, columnspan=3, sticky="nsew", padx=0, pady=(0, 1))
+            err_lbl = f"Failed to fetch encryption policies: {self.encryption_data['error']}\nNote: Requires Exchange Online PowerShell certificate auth."
+            ctk.CTkLabel(c, text=err_lbl, font=FONT_BODY_MEDIUM, text_color=COLOR_ERROR, justify="center").pack(padx=10, pady=12)
+        else:
+            m365_pols = self.encryption_data.get("m365_policies", [])
+            exc_deps = self.encryption_data.get("exchange_deps", [])
+            
+            posture = "Customer Key (Customer-Managed)" if (m365_pols or exc_deps) else "Microsoft-Managed Keys (Default)"
+            
+            m365_text = "\n".join([p["Name"] for p in m365_pols]) if m365_pols else "None detected"
+            exc_text = "\n".join([p["Name"] for p in exc_deps]) if exc_deps else "None detected"
+            
+            bg_style = COLOR_SURFACE
+            vals = [posture, m365_text, exc_text]
+            for c_idx, val in enumerate(vals):
+                c = ctk.CTkFrame(enc_grid, fg_color=bg_style, corner_radius=0)
+                c.grid(row=1, column=c_idx, sticky="nsew", padx=0, pady=(0, 1))
+                ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=450).pack(padx=10, pady=12, anchor="nw")
+
+        # --- DISCLAIMER ---
         disclaimer = ctk.CTkLabel(self.grid_frame, text="Note: Users can track inbound connectors displayed below to identify 3rd-party security apps.", font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_SUB, anchor="w")
         disclaimer.pack(fill="x", padx=15, pady=(5, 15))

--- a/telemetry/exchange/mail_security.py
+++ b/telemetry/exchange/mail_security.py
@@ -254,12 +254,12 @@ class MailSecurityFrame(ctk.CTkFrame):
                     ctk.CTkLabel(c, text=val, font=FONT_BODY_MEDIUM, text_color=COLOR_TEXT_MAIN, justify="left", wraplength=450).pack(padx=10, pady=12, anchor="nw")
                     
         # --- ENCRYPTION UI ---
-        ctk.CTkLabel(self.grid_frame, text="Data at Rest Encryption", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(fill="x", padx=15, pady=(20, 5))
+        ctk.CTkLabel(self.grid_frame, text="Encryption Key Management", font=FONT_HEADER_SMALL, text_color=COLOR_TEXT_MAIN).pack(fill="x", padx=15, pady=(20, 5))
         
         enc_grid = ctk.CTkFrame(self.grid_frame, fg_color=COLOR_SURFACE, corner_radius=0)
         enc_grid.pack(fill="x", padx=10, pady=(0, 10))
         
-        enc_headers = ["Encryption Posture", "Tenant-Level Policies (M365)", "Mailbox Policies (Exchange DEPs)"]
+        enc_headers = ["Key Management Model", "M365DataAtRestEncryptionPolicy", "DataEncryptionPolicy"]
         for i in range(3):
             enc_grid.grid_columnconfigure(i, weight=1)
             

--- a/telemetry/exchange/mail_security.py
+++ b/telemetry/exchange/mail_security.py
@@ -280,8 +280,8 @@ class MailSecurityFrame(ctk.CTkFrame):
             
             posture = "Customer Key (Customer-Managed)" if (m365_pols or exc_deps) else "Microsoft-Managed Keys (Default)"
             
-            m365_text = "\n".join([p["Name"] for p in m365_pols]) if m365_pols else "None detected"
-            exc_text = "\n".join([p["Name"] for p in exc_deps]) if exc_deps else "None detected"
+            m365_text = str(len(m365_pols)) if m365_pols else "None detected"
+            exc_text = str(len(exc_deps)) if exc_deps else "None detected"
             
             bg_style = COLOR_SURFACE
             vals = [posture, m365_text, exc_text]


### PR DESCRIPTION
## Description
This PR fully implements the Data at Rest Encryption policy detection as outlined in the implementation plan.

### Features
- Adds `core/powershell/scripts/export_encryption_policies.ps1` which uses the hybrid certificate auth to securely and silently query Exchange Online for `Get-M365DataAtRestEncryptionPolicy` and `Get-DataEncryptionPolicy`.
- Adds `core/powershell/encryption.py` to act as a seamless Python execution wrapper.
- Refactors `telemetry/exchange/mail_security.py` to execute both the Graph API (Subscribed SKUs) and the PowerShell script asynchronously using a `ThreadPoolExecutor`.
- Renders the detected M365 Customer Key or legacy Exchange DEPs into a new polished UI table within the Mail Security dashboard section.