### PR TITLE
fix(ui): prevent crash in batch ETA calculation when in-place archive scan is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env/
 outputs/
 data/
 test_*.py
+.DS_Store

--- a/ui/exchange_online_ui.py
+++ b/ui/exchange_online_ui.py
@@ -2604,7 +2604,8 @@ class MigrationEstimatorTool(ctk.CTk):
     # TODO Remove the need to provide config when only ETA is needed
     # Helper: Calculate ETA for subset
     config = self._get_scan_configuration()
-    if ENABLE_IN_PLACE_ARCHIVE_ETA:
+    in_place_archive_estimator = None
+    if ENABLE_IN_PLACE_ARCHIVE_ETA and self.factory.one_token_per_app_manager is not None:
       in_place_archive_estimator = self.factory.get_in_place_archive_estimator(use_delta_api=True)
     if ENABLE_SHARED_MAILBOX_ETA:
       shared_mail_box_estimator = self.factory.get_shared_mailbox_estimator()
@@ -2640,7 +2641,7 @@ class MigrationEstimatorTool(ctk.CTk):
             ETA_CONTACT_BATCH_TIME,
         )
       eta_in_place_archive = 0.0
-      if ENABLE_IN_PLACE_ARCHIVE_ETA:
+      if ENABLE_IN_PLACE_ARCHIVE_ETA and in_place_archive_estimator is not None:
         eta_in_place_archive = in_place_archive_estimator.calculate_migration_eta(
           {
             "item_counts": subset_df["In Place Archive Count"].tolist(),
@@ -2674,7 +2675,7 @@ class MigrationEstimatorTool(ctk.CTk):
           }
         )
 
-      if ENABLE_IN_PLACE_ARCHIVE_ETA:
+      if ENABLE_IN_PLACE_ARCHIVE_ETA and in_place_archive_estimator is not None:
         in_place_archive_estimator.shutdown()
       if ENABLE_SHARED_MAILBOX_ETA:
         shared_mail_box_estimator.shutdown()
@@ -2827,7 +2828,7 @@ class MigrationEstimatorTool(ctk.CTk):
           f" {self.format_eta(chunk['start_time'])}"
       )
 
-    if ENABLE_IN_PLACE_ARCHIVE_ETA:
+    if ENABLE_IN_PLACE_ARCHIVE_ETA and in_place_archive_estimator is not None:
       in_place_archive_estimator.shutdown()
     if ENABLE_SHARED_MAILBOX_ETA:
       shared_mail_box_estimator.shutdown()


### PR DESCRIPTION
### Summary
Fixes an unhandled exception (`Exception: One token per app manager not initialized!!`) that caused the application to crash after user discovery when generating reports for scans where In-Place Archive scanning was disabled or run offline.

### Root Cause
In `ui/exchange_online_ui.py`, the `calculate_migration_batches` method unconditionally instantiated `in_place_archive_estimator` whenever the global feature flag `ENABLE_IN_PLACE_ARCHIVE_ETA` was enabled (`True`). 
However, constructing the `EOInPlaceArchiveEstimator` requires `child_folder_url_invoker`, which depends on `one_token_per_app_manager` being initialized in `EstimatorFactory`. When a scan is executed with **In Place Archives** unchecked in the UI configuration, `one_token_per_app_manager` remains `None`, causing `factory.get_child_folder_url_invoker()` to throw an exception right before batch reports are rendered.

### Solution
- **Guarded Estimator Initialization:** Updated `calculate_migration_batches` to verify that `self.factory.one_token_per_app_manager is not None` before attempting to instantiate `in_place_archive_estimator`.
- **Safe Null Checks on Cleanup/Usage:** Added null-safety checks (`in_place_archive_estimator is not None`) before invoking `.calculate_migration_eta()` or `.shutdown()`. If In-Place Archive scanning is skipped, its contribution to the batch ETA gracefully defaults to `0.0` without disrupting the reporting workflow.

### Impact & Testing
- **Regression Free:** Does not alter existing scanning flows, API calls, or math calculations for active scans.

