### PR TITLE
fix: Enable mail checkbox to be disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ env/
 outputs/
 data/
 test_*.py
+.DS_Store
+tests/.DS_Store

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -101,7 +101,6 @@ def build_eo_resource_checkbox_list(self, ctk):
       corner_radius=4,
       fg_color=COLOR_PRIMARY,
       border_color=COLOR_TEXT_SUB,
-      state="disabled",
   ).pack(side="left", padx=10)
   ctk.CTkCheckBox(
       scan_options_frame,


### PR DESCRIPTION
### Summary
Removes the hardcoded `state="disabled"` lock on the **Emails** checkbox in `ui/utils.py`, allowing users to uncheck email message scanning and perform independent scans.

### Justification & Motivation
Previously, the **Emails** checkbox was disabled (`state="disabled"`) and forced to `True`. While email messages represent the primary volume for full Exchange Online migrations, deployment partners and IT administrators frequently need to perform targeted, modular scans on specific secondary workloads (such as **Contacts**, **Calendars**, or **Tasks** only) or re-run assessments after delta synchronizations.

### Changes & Technical Verification
- **UI Unlocked:** Removed `state="disabled"` from the `CTkCheckBox` initialization in `ui/utils.py`.
- **Backend Compatibility:** Verified that the core scanning pipeline (`exchange_online_ui.py`) and API scope builder (`_authenticate_if_needed`) already dynamically handle `config.scan_email == False`. When unselected, the tool cleanly skips email folder enumeration and omits `Mail.Read` from requested Graph scopes (unless required by shared mailboxes), aggregating accurate totals for active scopes only.
