### PR TITLE
fix(exchange-online): add multi-stage fallback and retry logic to CSV user resolution

### DIFF
--- a/ui/exchange_online_ui.py
+++ b/ui/exchange_online_ui.py
@@ -2869,7 +2869,8 @@ class MigrationEstimatorTool(ctk.CTk):
     if not emails:
       return []
     resolved = []
-    if url is None:
+    custom_url_provided = url is not None
+    if not custom_url_provided:
       url = ("{GRAPH_BASE_URL}/users?$filter=userPrincipalName eq"
               " '{cln}'&$select=id,userPrincipalName"
             )
@@ -2883,11 +2884,30 @@ class MigrationEstimatorTool(ctk.CTk):
       h = {"Authorization": f"Bearer {t}", "ConsistencyLevel": "eventual"}
       try:
         cln = email.replace("'", "''")
-        u = url.format(GRAPH_BASE_URL = GRAPH_BASE_URL, cln = cln)
-        r = s.get(u, headers=h, timeout=60)
-        if r.status_code == 200 and r.json().get("value"):
-          return r.json()["value"][0]
-      except:
+        if custom_url_provided:
+          target_urls = [url.format(GRAPH_BASE_URL=GRAPH_BASE_URL, cln=cln)]
+        else:
+          target_urls = [
+              f"{GRAPH_BASE_URL}/users?$filter=userPrincipalName eq '{cln}'&$select=id,userPrincipalName",
+              f"{GRAPH_BASE_URL}/users?$filter=mail eq '{cln}'&$select=id,userPrincipalName",
+              f"{GRAPH_BASE_URL}/users?$filter=proxyAddresses/any(c:c eq 'smtp:{cln}')&$select=id,userPrincipalName"
+          ]
+        for u in target_urls:
+          for attempt in range(3):
+            if self.stop_scan_event.is_set():
+              return None
+            try:
+              r = s.get(u, headers=h, timeout=60)
+              if r.status_code in (429, 503):
+                time.sleep(1 << attempt)
+                continue
+              if r.status_code == 200 and r.json().get("value"):
+                return r.json()["value"][0]
+              break
+            except Exception:
+              if attempt < 2:
+                time.sleep(1 << attempt)
+      except Exception:
         pass
       finally:
         manager.return_token_slot(token_data)


### PR DESCRIPTION
## COntext
When running Exchange Online estimations from a CSV input, user resolution currently uses a strict Microsoft Graph query (`userPrincipalName eq '{email}'`).

In some cases, client CSVs contain primary SMTP addresses or secondary aliases (`@domain.com`) that differ from internal Entra ID UPNs (`@tenant.onmicrosoft.com`). Because resolution previously only checked `userPrincipalName`, Graph API returned empty results (`value: []`), causing valid mailboxes to be silently dropped during user discovery.

Additionally, CSV resolution lacked exponential backoff retry logic, causing throttled requests (HTTP 429 / 503) to fail silently and drop mailboxes.

---

## Changes Included
- **Multi-Stage Fallback Resolution**: When resolving user CSVs (`url=None`), query Graph API in progressive order:
  1. `userPrincipalName eq '{email}'` (Exact UPN)
  2. `mail eq '{email}'` (Primary SMTP)
  3. `proxyAddresses/any(c:c eq 'smtp:{email}')` (Secondary Aliases)
- **Exponential Backoff Retries**: Added up to 3 retries with exponential backoff (`1s`, `2s`, `4s`) for HTTP 429 (Too Many Requests) and 503 (Service Unavailable) status codes during CSV resolution.
- **Preserved Custom URL Support**: Preserved dedicated URL resolution for M365 Group Mailboxes (`url` parameter) while adding throttling protection.

---

## Testing Performed
- Verified CSV resolution against Exchange Online tenants using UPNs, Primary SMTPs, and secondary proxy aliases.
- Confirmed syntax compilation via `py_compile ui/exchange_online_ui.py`.
- Verified that downstream batching, estimation, and final reporting function as expected without breaking changes.
