### PR TITLE
Fix scrollregion not updating for dynamically shown content in Exchange UI

### DIFF
--- a/ui/exchange_online_ui.py
+++ b/ui/exchange_online_ui.py
@@ -850,6 +850,14 @@ class MigrationEstimatorTool(ctk.CTk):
           self.create_batch_bar(master_container, w, max_batch_eta)
 
       self.view_results.update_idletasks()
+      # The dynamically rendered Gantt chart / batch details can change the
+      # scrollable content's total height, but the canvas scrollregion is
+      # not always recomputed automatically. Without this, content past the
+      # window's visible area (e.g. the disclaimer footnote) becomes
+      # unreachable until the window is manually resized.
+      self.view_results._parent_canvas.configure(
+          scrollregion=self.view_results._parent_canvas.bbox("all")
+      )
       try:
         self.view_results._parent_canvas.yview_moveto(current_scroll)
       except:
@@ -1116,6 +1124,16 @@ class MigrationEstimatorTool(ctk.CTk):
       self.adv_frame.pack(fill="x", pady=10, after=self.btn_adv)
       self.btn_adv.configure(text="Hide Advanced Settings ▲")
       self.adv_visible = True
+
+    # Revealing/hiding the advanced settings changes the scrollable
+    # content's total height, but CTkScrollableFrame does not always
+    # recompute its scroll region until the window is manually resized.
+    # Force a refresh so newly shown fields (e.g. Migration Plan Options)
+    # are reachable via scrolling right away.
+    self.scroll_connect.update_idletasks()
+    self.scroll_connect._parent_canvas.configure(
+        scrollregion=self.scroll_connect._parent_canvas.bbox("all")
+    )
 
   def browse_user_csv(self):
     f = filedialog.askopenfilename(filetypes=[("CSV", "*.csv")])


### PR DESCRIPTION
## Problem

In the Exchange Online planner UI, two spots add or remove widgets inside a `CTkScrollableFrame` *after* it has already been packed:

1. `toggle_adv()` — showing "Advanced Settings" packs in the Scan Settings checkboxes, Concurrency slider, and Migration Plan Options.
2. `render_paginated_view()` — the Gantt chart / Batch Details section is rebuilt dynamically once a scan finishes.

In both cases the scrollable canvas's scrollregion isn't recalculated when this happens, so the newly added content (e.g. the Migration Plan Options section, or the disclaimer footnote below Batch Details) ends up below the visible area with no way to scroll to it. The only workaround was manually resizing the window, which forces Tkinter to recompute the whole layout as a side effect.

## Fix

Explicitly recompute the scrollregion (`canvas.configure(scrollregion=canvas.bbox("all"))`) right after the content changes in both spots, so everything is reachable via scrolling immediately without needing to resize the window.

## Testing

Ran the Exchange Online planner locally, toggled Advanced Settings and ran a scan against a small test tenant without resizing the window — previously-clipped content (Migration Plan Options, and the disclaimer text at the bottom of the results view) is now reachable by scrolling right away.