### PR TITLE
Feature/encrypted files support

### DIFF
--- a/estimators/file_estimator.py
+++ b/estimators/file_estimator.py
@@ -10,6 +10,7 @@ from util.connectors import UrlInvoker
 from util.utils import ScanConfig, Bucket, FileSizeDistribution, LargeResource, create_batches, create_request_to_response_map, get_batch_responses_map, get_relative_url, process_pagination_responses
 from util.enums import FailureType, ResourceType
 from util.thread_safe_ds import ThreadSafeMap, ThreadSafeSortedSet, AtomicInt
+from util import file_encryption_detector
 
 import traceback
 import json
@@ -395,6 +396,9 @@ class FileEstimator(Estimator):
                     if self.config.include_file_versions:
                         metrics["siteMetrics"][top_level_site]["versionSize"] = metrics["siteMetrics"].get(top_level_site, {}).get("versionSize", 0) + self.drive_id_to_version_size.get(drive_id, 0)
                         metrics["siteMetrics"][top_level_site]["versionCount"] = metrics["siteMetrics"].get(top_level_site, {}).get("versionCount", 0) + self.drive_id_to_version_count.get(drive_id, 0)
+                    if self.config.scan_encrypted_files:
+                        metrics["siteMetrics"][top_level_site]["encryptedFileSize"] = metrics["siteMetrics"].get(top_level_site, {}).get("encryptedFileSize", 0) + self.drive_id_to_encrypted_file_size.get(drive_id, 0)
+                        metrics["siteMetrics"][top_level_site]["encryptedFileCount"] = metrics["siteMetrics"].get(top_level_site, {}).get("encryptedFileCount", 0) + self.drive_id_to_encrypted_file_count.get(drive_id, 0)
                     metrics["siteMetrics"][top_level_site]["folderCountExceedingDepthLimit"] =  metrics["siteMetrics"].get(top_level_site, {}).get("folderCountExceedingDepthLimit", 0) + drive_metric.get("folderCountExceedingDepthLimit", 0)
                     metrics["siteMetrics"][top_level_site]["fileCountExceedingDepthLimit"] =  metrics["siteMetrics"].get(top_level_site, {}).get("fileCountExceedingDepthLimit", 0) + drive_metric.get("fileCountExceedingDepthLimit", 0)
                 
@@ -1182,6 +1186,60 @@ class FileEstimator(Estimator):
             self._log_and_fail("Error in _get_drives", e, failures)
             return 0, 0
 
+    def _check_file_encryption(
+        self,
+        drive_id: str,
+        item_id: str,
+        file_size: int,
+        failures: List[Dict[str, str]],
+        drive_discovery_progress_metrics: ThreadSafeMap,
+        completed_drives: AtomicInt,
+        total_drives: int
+    ):
+        if self.is_hard_stop_requested():
+            return
+
+        try:
+            url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}/content"
+            
+            token_data = self.url_invoker.token_manager.get_valid_token_slot(self.logger)
+            token = token_data["token"]
+            session = self.url_invoker.token_manager.get_session()
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Range": "bytes=0-10239" # 10 KB
+            }
+            
+            try:
+                r = session.get(url, headers=headers, timeout=60)
+                if r.status_code in [200, 206]: # 206 Partial Content
+                    content = r.content
+                    status = file_encryption_detector.detect_encryption(content)
+                    if file_encryption_detector.is_encrypted(status):
+                        with self.encryption_metrics_lock:
+                            self.drive_id_to_encrypted_file_count[drive_id] = self.drive_id_to_encrypted_file_count.get(drive_id, 0) + 1
+                            self.drive_id_to_encrypted_file_size[drive_id] = self.drive_id_to_encrypted_file_size.get(drive_id, 0) + file_size
+                        
+                        drive_discovery_progress_metrics.increment("encryptedFileCount")
+                else:
+                    # Log error if needed
+                    pass
+            finally:
+                self.url_invoker.token_manager.return_token_slot(token_data)
+
+            self.processed_encryption_count.increment()
+            if self.processed_encryption_count.get_value() % 10 == 0:
+                self.progress_update_callback(
+                    "drive_discovery",
+                    count=completed_drives.get_value(),
+                    total_drives=total_drives,
+                    **drive_discovery_progress_metrics.get_all()
+                )
+
+        except Exception as e:
+            # Log exception
+            pass
+
     def _fetch_file_versions_size(
         self,
         drive_id: str,
@@ -1280,6 +1338,7 @@ class FileEstimator(Estimator):
     ):
         completed_drives = AtomicInt(0)
         self.processed_versions_count = AtomicInt(0)
+        self.processed_encryption_count = AtomicInt(0)
         total_drives = len(drive_ids)
         adj_list = {}
         parent_references: Dict[str, Dict[str, str]] = {}
@@ -1291,11 +1350,20 @@ class FileEstimator(Estimator):
 
         self.drive_id_to_version_size = {}
         self.drive_id_to_version_count = {}
+        self.drive_id_to_encrypted_file_size = {}
+        self.drive_id_to_encrypted_file_count = {}
         self.version_size_lock = threading.Lock()
+        self.encryption_metrics_lock = threading.Lock()
         self.versions_executor = None
+        self.encryption_executor = None
         if self.config.include_file_versions:
             from concurrent.futures import ThreadPoolExecutor
             self.versions_executor = ThreadPoolExecutor(max_workers=self.config.concurrency)
+        if self.config.scan_encrypted_files:
+            from concurrent.futures import ThreadPoolExecutor
+            if not self.versions_executor: # Reuse import if already done, though it's at top now? Wait, line 1 has it!
+                 pass # It is imported at line 1
+            self.encryption_executor = ThreadPoolExecutor(max_workers=self.config.concurrency)
 
         try:
             # use delta api to fetch the folders
@@ -1340,6 +1408,11 @@ class FileEstimator(Estimator):
                         if self.config.include_file_versions and self.versions_executor:
                             item_id = curr_response["id"]
                             self.versions_executor.submit(self._fetch_file_versions_size, drive_id, item_id, failures, drive_discovery_progress_metrics, completed_drives, total_drives)
+                        
+                        if self.config.scan_encrypted_files and self.encryption_executor:
+                            item_id = curr_response["id"]
+                            file_size = curr_response.get("size", 0)
+                            self.encryption_executor.submit(self._check_file_encryption, drive_id, item_id, file_size, failures, drive_discovery_progress_metrics, completed_drives, total_drives)
                             
                     elif "remoteItem" in curr_response:
                         drive_discovery_progress_metrics.increment("shortcutCount")
@@ -1435,6 +1508,8 @@ class FileEstimator(Estimator):
         finally:
             if self.config.include_file_versions and hasattr(self, "versions_executor") and self.versions_executor:
                 self.versions_executor.shutdown(wait=True)
+            if self.config.scan_encrypted_files and hasattr(self, "encryption_executor") and self.encryption_executor:
+                self.encryption_executor.shutdown(wait=True)
 
     def _calculate_drive_metrics(
         self, 

--- a/estimators/file_estimator.py
+++ b/estimators/file_estimator.py
@@ -11,6 +11,7 @@ from util.utils import ScanConfig, Bucket, FileSizeDistribution, LargeResource, 
 from util.enums import FailureType, ResourceType
 from util.thread_safe_ds import ThreadSafeMap, ThreadSafeSortedSet, AtomicInt
 from util import file_encryption_detector
+from util.constants import ENCRYPTED_FILE_ETA_MULTIPLIER
 
 import traceback
 import json
@@ -57,14 +58,32 @@ class FileEstimator(Estimator):
         batch_corpus_size = sum(item["size"] for item in items)
         batch_resource_count = sum(item["files"] for item in items)
 
-        average_batch_file_size = batch_corpus_size / batch_resource_count if batch_resource_count > 0 else 0
+        encrypted_corpus_size = sum(item.get("encrypted_size", 0.0) for item in items)
+        encrypted_resource_count = sum(item.get("encrypted_files", 0) for item in items)
 
-        max_qps_from_file_size = data.get("FILES_GLOBAL_CORPUS_SIZE_LIMIT") / average_batch_file_size if average_batch_file_size > 0 else data.get("FILES_GLOBAL_CORPUS_SIZE_LIMIT")
+        unencrypted_corpus_size = batch_corpus_size - encrypted_corpus_size
+        unencrypted_resource_count = batch_resource_count - encrypted_resource_count
+
+        # Unencrypted calculation
+        average_unencrypted_file_size = unencrypted_corpus_size / unencrypted_resource_count if unencrypted_resource_count > 0 else 0
+        max_qps_from_unencrypted_file_size = data.get("FILES_GLOBAL_CORPUS_SIZE_LIMIT") / average_unencrypted_file_size if average_unencrypted_file_size > 0 else data.get("FILES_GLOBAL_CORPUS_SIZE_LIMIT")
         max_qps_from_license_counts = data.get("FILES_GLOBAL_COUNT_LIMIT")
         
-        qps = min(max_qps_from_license_counts, max_qps_from_file_size)
+        qps_unencrypted = min(max_qps_from_license_counts, max_qps_from_unencrypted_file_size)
+        time_unencrypted = unencrypted_resource_count / qps_unencrypted if qps_unencrypted > 0 else 0
+
+        # Encrypted calculation
+        average_encrypted_file_size = encrypted_corpus_size / encrypted_resource_count if encrypted_resource_count > 0 else 0
         
-        time_in_seconds =  batch_resource_count / qps
+        encrypted_corpus_limit = data.get("FILES_GLOBAL_CORPUS_SIZE_LIMIT") * ENCRYPTED_FILE_ETA_MULTIPLIER
+        encrypted_count_limit = data.get("FILES_GLOBAL_COUNT_LIMIT") * ENCRYPTED_FILE_ETA_MULTIPLIER
+        
+        max_qps_from_encrypted_file_size = encrypted_corpus_limit / average_encrypted_file_size if average_encrypted_file_size > 0 else encrypted_corpus_limit
+        
+        qps_encrypted = min(encrypted_count_limit, max_qps_from_encrypted_file_size)
+        time_encrypted = encrypted_resource_count / qps_encrypted if qps_encrypted > 0 else 0
+
+        time_in_seconds = time_unencrypted + time_encrypted
         return time_in_seconds / 3600
 
     def calculate_resource_metrics(

--- a/ui/files_ui.py
+++ b/ui/files_ui.py
@@ -793,7 +793,9 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
             "size": row.get("Corpus Size", 0),
             "files": int(row.get("File Count", 0)),
             "folders": int(row.get("Folder Count", 0)),
-            "shortcuts": int(row.get("Shortcut Count", 0))
+            "shortcuts": int(row.get("Shortcut Count", 0)),
+            "encrypted_files": int(row.get("Encrypted File Count", 0)) if "Encrypted File Count" in subset_df.columns else 0,
+            "encrypted_size": float(row.get("Encrypted File Size", 0)) if "Encrypted File Size" in subset_df.columns else 0.0
         })
         
       data = {
@@ -1041,14 +1043,14 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
       if getattr(self, "val_include_file_versions", False):
         self.create_stat_card(card_frame, "Total Historical File Version Size", f"{self.format_size(sum([entry.get('versionSize', 0) for entry in data.get('siteMetrics', {}).values()]))}", "📄")
         self.create_stat_card(card_frame, "Total Historical File Version Count", f"{sum([entry.get('versionCount', 0) for entry in data.get('siteMetrics', {}).values()]):,}", "📄")
-      if getattr(self, "val_scan_encrypted_files", False):
-        self.create_stat_card(card_frame, "Total Encrypted File Size", f"{self.format_size(sum([entry.get('encryptedFileSize', 0) for entry in data.get('siteMetrics', {}).values()]))}", "🔒")
-        self.create_stat_card(card_frame, "Total Encrypted File Count", f"{sum([entry.get('encryptedFileCount', 0) for entry in data.get('siteMetrics', {}).values()]):,}", "🔒")
       self.create_stat_card(card_frame, "Site Collection Count", f"{data.get('siteCount'):,}", "🏢")
       self.create_stat_card(card_frame, "Subsite Count", f"{data.get('subsiteCount'):,}", "🏢")
       self.create_stat_card(card_frame, "Document Library Count", f"{sum(data.get('driveCounts', {}).values()):,}", "📁")
       self.create_stat_card(card_frame, "Folder Count", f"{data.get('folderCount', 0):,}", "📁")
       self.create_stat_card(card_frame, "File Count", f"{data.get('fileCount', 0):,}", "📄")
+      if getattr(self, "val_scan_encrypted_files", False):
+        self.create_stat_card(card_frame, "Total Encrypted File Count", f"{sum([entry.get('encryptedFileCount', 0) for entry in data.get('siteMetrics', {}).values()]):,}", "🔒")
+        self.create_stat_card(card_frame, "Total Encrypted File Size", f"{self.format_size(sum([entry.get('encryptedFileSize', 0) for entry in data.get('siteMetrics', {}).values()]))}", "🔒")
       self.create_stat_card(card_frame, "Shortcut Count", f"{data.get('shortcutCount', 0):,}", "🔗")
       self.create_stat_card(card_frame, "List Count", f"{data.get('listCount', 0):,}", "🗃️")
       self.create_stat_card(card_frame, "Folder count beyond depth limit 100", f"{data.get('folderCountExceedingDepthLimit', 0):,}", "📁")
@@ -1371,6 +1373,13 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
               ("Total Historical File Version Size", self.format_size(total_version_size)),
               ("Total Historical File Version Count", total_version_count),
           ])
+      if getattr(self, "val_scan_encrypted_files", False):
+          total_encrypted_size = sum([entry.get('encryptedFileSize', 0) for entry in data.get('siteMetrics', {}).values()])
+          total_encrypted_count = sum([entry.get('encryptedFileCount', 0) for entry in data.get('siteMetrics', {}).values()])
+          summary_rows.extend([
+              ("Total Encrypted File Size", self.format_size(total_encrypted_size)),
+              ("Total Encrypted File Count", total_encrypted_count),
+          ])
       
       summary_rows.extend([
           ("Site Collection Count", data.get("siteCount", 0)),
@@ -1446,6 +1455,9 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
 
         if getattr(self, "val_include_file_versions", False):
           row.extend(["Historical File Version Count", "Historical File Version Size"])
+
+        if getattr(self, "val_scan_encrypted_files", False):
+          row.extend(["Encrypted File Count", "Encrypted File Size"])
 
         if self.show_eta:
           row.append("Suggested Batch")
@@ -1527,6 +1539,12 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
               row.extend([
                   s_data.get("versionCount", 0),
                   self.format_size(s_data.get("versionSize", 0))
+              ])
+
+            if getattr(self, "val_scan_encrypted_files", False):
+              row.extend([
+                  s_data.get("encryptedFileCount", 0),
+                  self.format_size(s_data.get("encryptedFileSize", 0))
               ])
 
             if self.show_eta:

--- a/ui/files_ui.py
+++ b/ui/files_ui.py
@@ -1041,6 +1041,9 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
       if getattr(self, "val_include_file_versions", False):
         self.create_stat_card(card_frame, "Total Historical File Version Size", f"{self.format_size(sum([entry.get('versionSize', 0) for entry in data.get('siteMetrics', {}).values()]))}", "📄")
         self.create_stat_card(card_frame, "Total Historical File Version Count", f"{sum([entry.get('versionCount', 0) for entry in data.get('siteMetrics', {}).values()]):,}", "📄")
+      if getattr(self, "val_scan_encrypted_files", False):
+        self.create_stat_card(card_frame, "Total Encrypted File Size", f"{self.format_size(sum([entry.get('encryptedFileSize', 0) for entry in data.get('siteMetrics', {}).values()]))}", "🔒")
+        self.create_stat_card(card_frame, "Total Encrypted File Count", f"{sum([entry.get('encryptedFileCount', 0) for entry in data.get('siteMetrics', {}).values()]):,}", "🔒")
       self.create_stat_card(card_frame, "Site Collection Count", f"{data.get('siteCount'):,}", "🏢")
       self.create_stat_card(card_frame, "Subsite Count", f"{data.get('subsiteCount'):,}", "🏢")
       self.create_stat_card(card_frame, "Document Library Count", f"{sum(data.get('driveCounts', {}).values()):,}", "📁")

--- a/ui/files_ui.py
+++ b/ui/files_ui.py
@@ -1598,6 +1598,21 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         )
         if not should_continue:
             return
+
+    if self.val_scan_encrypted_files:
+        warning_msg = (
+            "Enabling 'Scan for Encrypted Files (RMS/MIP)' will cause performance degradation "
+            "as it requires fetching content headers for every single file to detect encryption. "
+            "It is highly recommended to only enable this if you need to identify RMS/MIP protected files."
+        )
+        should_continue = messagebox.askyesno(
+            title="Performance Warning",
+            message=warning_msg,
+            icon="warning",
+            parent=self
+        )
+        if not should_continue:
+            return
       
     disclaimer_text = (
         "The estimations provided by this tool are calculated projections"

--- a/ui/files_ui.py
+++ b/ui/files_ui.py
@@ -68,6 +68,7 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
     self.include_team_sites = ctk.BooleanVar(value=False)
     self.include_recycle_bin_contents = ctk.BooleanVar(value=False)
     self.include_file_versions = ctk.BooleanVar(value=False)
+    self.scan_encrypted_files = ctk.BooleanVar(value=False)
     self.eta_min_users = ctk.IntVar(value=1000)
     self.eta_max_users = ctk.IntVar(value=5000)
 
@@ -196,6 +197,15 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         fg_color=COLOR_PRIMARY,
         border_color=COLOR_TEXT_SUB,
     ).pack(side="left", padx=10)
+
+    ctk.CTkCheckBox(
+        additional_settings_frame,
+        text="Scan for Encrypted Files (RMS/MIP)",
+        variable=self.scan_encrypted_files,
+        corner_radius=4,
+        fg_color=COLOR_PRIMARY,
+        border_color=COLOR_TEXT_SUB,
+    ).pack(side="left", padx=10)
     
     # Concurrency settings
     ui_utils.build_concurrency_settings_slider(self, ctk, useConcurrencyHeading=True)
@@ -261,6 +271,7 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         file_count = msg.get("fileCount", 0)
         shortcut_count = msg.get("shortcutCount", 0)
         version_count = msg.get("versionCount", 0)
+        encrypted_file_count = msg.get("encryptedFileCount", 0)
         status = msg.get("status", "Scanning...")
         if "drives" in self.prog_widgets:
           widget = self.prog_widgets["drives"]["lbl"]
@@ -277,6 +288,8 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
             text += f" | Shortcuts: {shortcut_count}"
           if version_count > 0:
             text += f" | Versions: {version_count}"
+          if encrypted_file_count > 0:
+            text += f" | Encrypted Files: {encrypted_file_count}"
           if widget.winfo_exists():
             widget.configure(
                 text=text
@@ -600,6 +613,9 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         if getattr(self, "val_include_file_versions", False):
             row_data["Historical File Version Count"] = s_data.get("versionCount", 0)
             row_data["Historical File Version Size"] = s_data.get("versionSize", 0)
+        if getattr(self, "val_scan_encrypted_files", False):
+            row_data["Encrypted File Count"] = s_data.get("encryptedFileCount", 0)
+            row_data["Encrypted File Size"] = s_data.get("encryptedFileSize", 0)
             
         site_data.append(row_data)
       df = pd.DataFrame(site_data)
@@ -660,6 +676,8 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         df_output["Recycle Bin Size"] = df_output["Recycle Bin Size"].apply(self.format_size)
       if "Historical File Version Size" in df_output.columns:
         df_output["Historical File Version Size"] = df_output["Historical File Version Size"].apply(self.format_size)
+      if "Encrypted File Size" in df_output.columns:
+        df_output["Encrypted File Size"] = df_output["Encrypted File Size"].apply(self.format_size)
       df_output.rename(columns={"Site Id": "Site URL/Name"}, inplace=True)
       if "SortMetric" in df_output.columns:
         df_output.drop(columns=["SortMetric"], inplace=True)
@@ -1520,6 +1538,7 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
     config.includeTeamSites = self.val_include_team_sites
     config.include_recycle_bin_contents = self.val_include_recycle_bin_contents
     config.include_file_versions = self.val_include_file_versions
+    config.scan_encrypted_files = self.val_scan_encrypted_files
     return config
 
   def start_scan(self):    
@@ -1538,6 +1557,7 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
     self.val_include_team_sites = self.include_team_sites.get()
     self.val_include_recycle_bin_contents = self.include_recycle_bin_contents.get()
     self.val_include_file_versions = self.include_file_versions.get()
+    self.val_scan_encrypted_files = self.scan_encrypted_files.get()
     self.val_eta_min_users = self.eta_min_users.get()
     self.val_eta_max_users = self.eta_max_users.get()
     self.val_parallel_batches = self.parallel_batches.get()

--- a/util/constants.py
+++ b/util/constants.py
@@ -77,6 +77,7 @@ IPA_ETA_MULTIPLIER = 1.1
 
 FILES_GLOBAL_COUNT_LIMIT = 4  # 4 files/folders per second
 FILES_GLOBAL_CORPUS_SIZE_LIMIT = (400 * 1024 * 1024 * 1024) // 3600  # 400 GB per hour in bytes per second
+ENCRYPTED_FILE_ETA_MULTIPLIER = 0.5 # 0.5x speed for encrypted files
 
 ENABLE_CALENDAR_ETA = False
 ETA_CALENDAR_GLOBAL_LIMIT = 50

--- a/util/file_encryption_detector.py
+++ b/util/file_encryption_detector.py
@@ -1,0 +1,47 @@
+"""Utility to detect encryption in file headers."""
+
+CFBF_MAGIC = b'\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1'
+PDF_MAGIC = b'%PDF'
+ZIP_MAGIC = b'PK\x03\x04'
+
+DRM_CONTENT_BYTES = "DRMContent".encode('utf-16-le')
+DATA_SPACES_BYTES = "DataSpaces".encode('utf-16-le')
+IRM_SERVICES_BYTES = "/MicrosoftIRMServices".encode('ascii')
+
+class EncryptionStatus:
+    RMS_ENCRYPTED_OFFICE = "RMS/MIP ENCRYPTED (Office Document with DRM Content)"
+    RMS_ENCRYPTED_PDF = "RMS/MIP ENCRYPTED (PDF with MicrosoftIRMServices)"
+    UNENCRYPTED_OR_STANDARD_PDF = "NOT ENCRYPTED (Standard PDF, no Microsoft RMS found in header)"
+    UNENCRYPTED_ZIP_OR_OFFICE = "NOT ENCRYPTED (Standard Office Document / ZIP)"
+    UNENCRYPTED_OR_OTHER = "LIKELY NOT ENCRYPTED (Unsupported format, no encryption markers)"
+    UNKNOWN_TOO_SMALL = "UNKNOWN (File too small to analyze)"
+
+def starts_with(header: bytes, prefix: bytes) -> bool:
+    return header.startswith(prefix)
+
+def contains_bytes(header: bytes, target: bytes) -> bool:
+    return target in header
+
+def detect_encryption(header: bytes) -> str:
+    if len(header) < 4:
+        return EncryptionStatus.UNKNOWN_TOO_SMALL
+
+    # 1. Check for Office CFBF Container (MIP/RMS)
+    if starts_with(header, CFBF_MAGIC):
+        if contains_bytes(header, DRM_CONTENT_BYTES) or contains_bytes(header, DATA_SPACES_BYTES):
+            return EncryptionStatus.RMS_ENCRYPTED_OFFICE
+
+    # 2. Check for PDF (MIP/RMS Protected PDFs)
+    if starts_with(header, PDF_MAGIC):
+        if contains_bytes(header, IRM_SERVICES_BYTES):
+            return EncryptionStatus.RMS_ENCRYPTED_PDF
+        return EncryptionStatus.UNENCRYPTED_OR_STANDARD_PDF
+
+    # 3. Check for standard ZIP (Unencrypted Office files are standard ZIPs)
+    if starts_with(header, ZIP_MAGIC):
+        return EncryptionStatus.UNENCRYPTED_ZIP_OR_OFFICE
+
+    return EncryptionStatus.UNENCRYPTED_OR_OTHER
+
+def is_encrypted(status: str) -> bool:
+    return status in [EncryptionStatus.RMS_ENCRYPTED_OFFICE, EncryptionStatus.RMS_ENCRYPTED_PDF]

--- a/util/utils.py
+++ b/util/utils.py
@@ -35,6 +35,7 @@ class ScanConfig:
   max_allowed_depth: int = 100
   include_recycle_bin_contents: bool = False
   include_file_versions: bool = False
+  scan_encrypted_files: bool = False
 
 @dataclass
 class RequestResponsePair:


### PR DESCRIPTION
# 📋 Encrypted Files (RMS/MIP) Support

## 📝 Summary
This PR adds support for early detection of **RMS/MIP Encrypted Files** (Office Documents and PDFs) during the Files (OneDrive/SharePoint) estimation scan.

Similar to the **Encrypted Emails** feature, this allows administrators to identify protected files early in the assessment process without requiring full downloads, and provides a more realistic migration timeline projection by accounting for decryption overhead.

## 🛠️ Key Changes
- **Binary Header Scanning**: Added `util/file_encryption_detector.py` to inspect file magic bytes and markers (fetching only the **first 10KB** via HTTP Range header) to detect `DRMContent` or `/MicrosoftIRMServices` without downloading full content.
-  **Feature Toggle**: Added a new **"Scan for Encrypted Files (RMS/MIP)"** checkbox in the UI under **Advanced Settings -> Additional Settings**.
- **Asynchronous & Efficient**: Integrated detection asynchronously into the `FileEstimator` crawling loop using a dedicated thread pool to minimize performance impact on metadata crawling.
-  **Optimized ETA Logic**: Introduced `ENCRYPTED_FILE_ETA_MULTIPLIER` (0.5x speed) in constants. The Files ETA calculation is now split into **encrypted** and **unencrypted** pipelines to project realistic timelines.
- **Reporting & Dashboard**:
  - Added dedicated **Stat Cards** for Encrypted File Count/Size to the on-screen dashboard (positioned right after standard file counts for easy comparison).
  - Ensured encrypted metrics are fully exported in the **CSV Summary** and **Site Details**.

##  Related PRs
- 📧 Builds upon the encryption detection patterns and infrastructure established in **Encrypted Emails Support** (#100).

---

Screenshots:
<img width="1689" height="1052" alt="file 1" src="https://github.com/user-attachments/assets/8104ea79-ebbb-46df-a054-2795ad43e64b" />

<img width="1697" height="933" alt="image" src="https://github.com/user-attachments/assets/57ad7945-a750-49fb-b67a-91bd2b612715" />


<img width="1698" height="1063" alt="file 2" src="https://github.com/user-attachments/assets/1071d960-18fb-4292-9a74-d8b949cd656b" />

<img width="1697" height="1055" alt="file 3" src="https://github.com/user-attachments/assets/24e1f305-8c79-4114-adc8-a67656309a99" />


