### PR TITLE
Add performance warning disclaimer for encrypted emails scan

### DIFF
--- a/ui/exchange_online_ui.py
+++ b/ui/exchange_online_ui.py
@@ -1321,6 +1321,20 @@ class MigrationEstimatorTool(ctk.CTk):
       self.after(100, self.process_log_queue)
 
   def start_scan(self):
+    if self.scan_encrypted_email.get():
+        warning_msg = (
+            "Enabling 'Scan for Encrypted Emails' will cause performance degradation "
+            "as it requires fetching content headers for emails to detect encryption. "
+            "It is highly recommended to only enable this if you need to identify RMS/MIP protected emails."
+        )
+        should_continue = messagebox.askyesno(
+            title="Performance Warning",
+            message=warning_msg,
+            icon="warning",
+            parent=self
+        )
+        if not should_continue:
+            return
     disclaimer_text = (
         "The estimations provided by this tool are calculated projections"
         " intended for preliminary planning only. Actual migration timelines"


### PR DESCRIPTION
# 📋 PR Description: Add Performance Warning for Encrypted Emails Scan

## 📝 Summary
This PR adds a **Performance Warning** disclaimer to the Exchange Online planner UI when the **"Encrypted Emails"** scan option is enabled.

Similar to the warnings for historical versions in file scans, this alerts the administrator that enabling deep scanning for encrypted emails can cause performance degradation due to the additional overhead of fetching and inspecting headers/content for each email.

## 🛠️ Key Changes
- ⚠️ **Interactive Warning Popup**: Added a `messagebox.askyesno` dialog in `ui/exchange_online_ui.py` that triggers immediately after clicking "Start Scan" if "Encrypted Emails" is checked.
- 🛑 **Guardrail**: Allows the user to cancel and uncheck the option if they did not intend to run a heavy scan, preventing accidental performance hits on large tenants.

## 🧪 Testing Instructions
1. Launch the **Exchange** workload.
2. Check the **"Encrypted Emails"** box under Scan Settings.
3. Click **Start Scan**.
4. Verify that a popup appears warning about "performance degradation".
5. Clicking **No** should abort the scan. Clicking **Yes** should proceed to the standard Estimation Disclaimer.

---

### Screenshots:

![Uploading image.png…]()

