### PR TITLE
fix: handle TypeError in UrlInvoker logging

### DIFF
--- a/util/connectors.py
+++ b/util/connectors.py
@@ -82,7 +82,7 @@ class UrlInvoker():
                     break
 
             if len(failed_responses) > 0:
-                logger(f"Consistent failures observed for the following: {",".join(response.get("body") for response in failed_responses)}")
+                logger(f"Consistent failures observed for the following: {",".join(str(response.get("body")) for response in failed_responses)}")
 
         except Exception as e:
             logger(f"Error in {context}: {e}")


### PR DESCRIPTION
Fixes #63

**Root cause:** Line 85 of util/connectors.py calls str.join() on response.get('body') values that are Python dicts (parsed JSON from Graph API error responses). str.join() requires string items, so it throws TypeError. This TypeError is caught by the surrounding try/except Exception block on line 87, which masks the actual Graph API error and logs a meaningless Python syntax error instead.

**Fix:** Wrap with str() to safely stringify before joining.