### PR TITLE
Update error handling for when the tenant does not have public folders

### DIFF
--- a/core/powershell/scripts/get_mailbox_and_folder_stats.ps1
+++ b/core/powershell/scripts/get_mailbox_and_folder_stats.ps1
@@ -71,7 +71,11 @@ try {
             $pfCount = 0
         }
     } catch {
-        $errors["PublicFolders"] = $_.Exception.Message
+        if ($_.Exception.Message -match "Specify the -Organization parameter") {
+            $pfCount = 0
+        } else {
+            $errors["PublicFolders"] = $_.Exception.Message
+        }
     }
 
     # 2b. Query Mail-Enabled Public Folders
@@ -84,7 +88,11 @@ try {
             $mailPfCount = 0
         }
     } catch {
-        $errors["MailPublicFolders"] = $_.Exception.Message
+        if ($_.Exception.Message -match "Specify the -Organization parameter") {
+            $mailPfCount = 0
+        } else {
+            $errors["MailPublicFolders"] = $_.Exception.Message
+        }
     }
 
     # 2c. Query Public Folder Stats (Size)
@@ -112,7 +120,11 @@ try {
             $pfTotalBytes = 0
         }
     } catch {
-        $errors["PublicFolderStats"] = $_.Exception.Message
+        if ($_.Exception.Message -match "Specify the -Organization parameter") {
+            $pfTotalBytes = 0
+        } else {
+            $errors["PublicFolderStats"] = $_.Exception.Message
+        }
     }
 
     # Output results as JSON
@@ -124,7 +136,7 @@ try {
         MailPublicFoldersCount = $mailPfCount
         Errors = $errors
     }
-    $result | ConvertTo-Json
+    $result | ConvertTo-Json -Depth 3
 }
 finally {
     Disconnect-ExchangeOnline -Confirm:$false -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary of Changes
- Updated error handling in `get_mailbox_and_folder_stats.ps1` when querying Public Folders, Mail-Enabled Public Folders, and Public Folder Statistics.
- Gracefully handles tenants without public folders (which return 'Specify the -Organization parameter' exception) by setting counts and sizes to 0 instead of flagging an error.
- Formats result JSON with depth 3 (`ConvertTo-Json -Depth 3`) to ensure complete serialization of nested objects.