### PR TITLE
fix(telemetry): Surface Dataverse authentication and API errors in Power Automate telemetry

### DIFF
--- a/telemetry/power_automate.py
+++ b/telemetry/power_automate.py
@@ -164,6 +164,7 @@ class PowerAutomateScanner:
         active_tier_counts = {"Personal Productivity": 0, "Enterprise/Departmental": 0}
         premium_connectors_found = set()
         custom_connectors_found = set()
+        errors = []
         
         script_dir = os.path.dirname(os.path.abspath(__file__)) if '__file__' in globals() else os.getcwd()
         reports_dir = os.path.join(script_dir, "reports", f"{self.tenant_id}_{self.client_id}")
@@ -361,6 +362,7 @@ class PowerAutomateScanner:
                                 pass
                 except Exception as e:
                     self.logger.error(f"      [X] Failed to authenticate against Dataverse instance {dv_url}: {e}")
+                    errors.append(f"Dataverse Authentication ({dv_url}): {e}")
 
         complex_active_count = 0
         complex_inactive_count = 0
@@ -382,7 +384,8 @@ class PowerAutomateScanner:
             "custom_connectors": list(custom_connectors_found),
             "complex_logic_flows_path": complex_logic_flows_path,
             "complex_active_count": complex_active_count,
-            "complex_inactive_count": complex_inactive_count
+            "complex_inactive_count": complex_inactive_count,
+            "errors": errors,
         }
 
         self.logger.info("Step End: Analysis complete.")


### PR DESCRIPTION
### Summary of Changes

- **Backend Error Tracking in `telemetry/power_automate.py`**:
  - Initialized `errors = []` in `PowerAutomateScanner.scan_flows()`.
  - Enables the UI (`EcosystemIntegrationsAutomationView`) to immediately detect Dataverse errors, suppress empty tables, and render the red error banner with the exact error details.