### PR TITLE
feat(ui): Add modular section fetch status indicators to sidebar navigation

### DIFF
--- a/flet_ui/components/__init__.py
+++ b/flet_ui/components/__init__.py
@@ -6,11 +6,19 @@ from flet_ui.components.dialogs import (
     show_delegated_auth_learn_more_dialog,
     show_upload_certificate_dialog,
 )
+from flet_ui.components.section_status_indicator import (
+    SectionStatus,
+    SectionStatusIndicator,
+    create_section_status_indicator,
+)
 from flet_ui.components.telemetry_card import TelemetryCard
 
 __all__ = [
     "AppCard",
     "TelemetryCard",
+    "SectionStatus",
+    "SectionStatusIndicator",
+    "create_section_status_indicator",
     "show_upload_certificate_dialog",
     "show_cert_decryption_error_dialog",
     "show_delegated_auth_learn_more_dialog",

--- a/flet_ui/components/section_status_indicator.py
+++ b/flet_ui/components/section_status_indicator.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Section status indicator component for sidebar navigation in Flet UI."""
+
+from enum import Enum
+from typing import Optional
+import flet as ft
+from flet_ui.styles import COLOR_ERROR, COLOR_PRIMARY, COLOR_TEXT_SECONDARY
+
+
+class SectionStatus(str, Enum):
+    """Status lifecycle states for telemetry section data fetches."""
+    IDLE = "idle"
+    LOADING = "loading"
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+class SectionStatusIndicator(ft.Container):
+    """Reusable indicator control displaying section fetch status with tooltips."""
+
+    def __init__(self, status: str = SectionStatus.IDLE, is_selected: bool = False):
+        super().__init__()
+        self.status = status
+        self.is_selected = is_selected
+        self.padding = ft.Padding(0, 0, 2, 0)
+        self.content = self._build_indicator()
+
+    def set_status(self, status: str, is_selected: Optional[bool] = None):
+        """Updates current status and re-renders the indicator."""
+        self.status = status
+        if is_selected is not None:
+            self.is_selected = is_selected
+        self.content = self._build_indicator()
+        try:
+            self.update()
+        except Exception:
+            pass
+
+    def _build_indicator(self) -> Optional[ft.Control]:
+        """Builds the appropriate icon/spinner control for current status."""
+        if self.status == SectionStatus.LOADING:
+            self.tooltip = "Fetching telemetry data..."
+            self.visible = True
+            return ft.ProgressRing(
+                width=15,
+                height=15,
+                stroke_width=2.2,
+                color=COLOR_PRIMARY if self.is_selected else "#0284C7",
+            )
+        elif self.status == SectionStatus.SUCCESS:
+            self.tooltip = "Fetch complete without errors"
+            self.visible = True
+            return ft.Icon(
+                ft.Icons.CHECK_ROUNDED,
+                size=18,
+                color="#16A34A",
+            )
+        elif self.status == SectionStatus.ERROR:
+            self.tooltip = "Fetch complete with errors"
+            self.visible = True
+            return ft.Icon(
+                ft.Icons.CHECK_ROUNDED,
+                size=18,
+                color=COLOR_ERROR,
+            )
+        else:
+            self.visible = False
+            self.tooltip = None
+            return None
+
+
+def create_section_status_indicator(
+    status: str = SectionStatus.IDLE, is_selected: bool = False
+) -> Optional[ft.Control]:
+    """Factory helper creating a status indicator control if status is active."""
+    if status == SectionStatus.IDLE or not status:
+        return None
+    return SectionStatusIndicator(status=status, is_selected=is_selected)

--- a/flet_ui/views/sections/__init__.py
+++ b/flet_ui/views/sections/__init__.py
@@ -14,12 +14,14 @@
 
 """Telemetry modular section views for Flet UI."""
 
+from flet_ui.views.sections.base_section_view import BaseSectionView
 from flet_ui.views.sections.identity_licensing_view import IdentityLicensingView
 from flet_ui.views.sections.app_usage_adoption_view import AppUsageAdoptionView
 from flet_ui.views.sections.security_compliance_view import SecurityComplianceGovernanceView
 from flet_ui.views.sections.ecosystem_integrations_view import EcosystemIntegrationsAutomationView
 
 __all__ = [
+    "BaseSectionView",
     "IdentityLicensingView",
     "AppUsageAdoptionView",
     "SecurityComplianceGovernanceView",

--- a/flet_ui/views/sections/app_usage_adoption_view.py
+++ b/flet_ui/views/sections/app_usage_adoption_view.py
@@ -31,6 +31,7 @@ from core.graph.files.sharepoint import run_sharepoint_pipeline
 from core.graph.files.onedrive import run_onedrive_pipeline
 from core.graph.files.msteams_overview import run_msteams_pipeline
 from core.graph.exchange.calendar import run_calendar_telemetry_pipeline
+from flet_ui.views.sections.base_section_view import BaseSectionView
 from flet_ui.components.telemetry_card import TelemetryCard
 from flet_ui.styles import (
     COLOR_PRIMARY,
@@ -42,7 +43,7 @@ from flet_ui.styles import (
 logger = logging.getLogger("M365TelemetryAsyncLogger.AppUsageAdoptionView")
 
 
-class AppUsageAdoptionView(ft.Container):
+class AppUsageAdoptionView(BaseSectionView):
     """View rendering all App Usage, Adoption & Collaboration telemetry cards with max 2 concurrency."""
 
     def __init__(
@@ -51,16 +52,15 @@ class AppUsageAdoptionView(ft.Container):
         tenant: str = "",
         client: str = "",
         secret: str = "",
+        on_status_change: Optional[Callable[[str], None]] = None,
     ):
-        super().__init__()
-        self.page_ref = page
-        self.tenant = tenant
-        self.client_id = client
-        self.secret = secret
-
-        self.expand = True
-        self.is_fetched = False
-        self.is_fetching = False
+        super().__init__(
+            page=page,
+            tenant=tenant,
+            client=client,
+            secret=secret,
+            on_status_change=on_status_change,
+        )
 
         # Card container with vertical scrolling
         self.cards_column = ft.Column(
@@ -169,6 +169,19 @@ class AppUsageAdoptionView(ft.Container):
             on_reload=lambda: self._reload_card(self._fetch_calendar_worker),
         )
 
+        # Register cards with base class for error status tracking
+        self.register_cards(
+            self.m365_apps_card,
+            self.active_users_card,
+            self.mailbox_card,
+            self.email_clients_card,
+            self.pst_card,
+            self.sharepoint_card,
+            self.onedrive_card,
+            self.teams_card,
+            self.calendar_card,
+        )
+
         # Initial Placeholder State
         self.placeholder = self._build_placeholder()
 
@@ -233,22 +246,6 @@ class AppUsageAdoptionView(ft.Container):
             ],
         )
 
-    def _safe_run_on_ui(self, callback: Callable):
-        """Dispatches UI updates safely on the event loop."""
-        try:
-            loop = getattr(self.page_ref, "loop", None)
-            if loop and callable(getattr(loop, "is_running", None)) and loop.is_running() and not isinstance(loop, ft.Page):
-                loop.call_soon_threadsafe(callback)
-            else:
-                callback()
-        except Exception:
-            callback()
-
-    def _reload_card(self, worker_func: Callable):
-        """Asynchronously executes single card reload in a daemon thread."""
-        import threading
-        threading.Thread(target=lambda: worker_func(is_reload=True), daemon=True).start()
-
     def fetch_all_data(self):
         """Initiates concurrent data fetch with maximum 2 parallel worker threads."""
         if self.is_fetching:
@@ -256,6 +253,7 @@ class AppUsageAdoptionView(ft.Container):
 
         self.is_fetching = True
         self.is_fetched = True
+        self._notify_status("loading")
 
         self.cards_column.controls.clear()
 
@@ -362,6 +360,7 @@ class AppUsageAdoptionView(ft.Container):
                     self.update()
                 except Exception:
                     pass
+                self._notify_status(self._check_completion_status())
 
             self._safe_run_on_ui(_on_all_completed)
 

--- a/flet_ui/views/sections/base_section_view.py
+++ b/flet_ui/views/sections/base_section_view.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base class for modular telemetry section views in Flet UI."""
+
+import threading
+from typing import Callable, List, Optional
+import flet as ft
+from flet_ui.components.section_status_indicator import SectionStatus
+
+
+class BaseSectionView(ft.Container):
+    """Abstract base container providing uniform state, UI callbacks, and status reporting."""
+
+    def __init__(
+        self,
+        page: ft.Page,
+        tenant: str = "",
+        client: str = "",
+        secret: str = "",
+        on_status_change: Optional[Callable[[str], None]] = None,
+    ):
+        super().__init__()
+        self.page_ref = page
+        self.tenant = tenant
+        self.client_id = client
+        self.secret = secret
+        self.on_status_change = on_status_change
+
+        self.expand = True
+        self.is_fetched = False
+        self.is_fetching = False
+        self.status = SectionStatus.IDLE
+        self._registered_cards: List[ft.Control] = []
+
+    def register_cards(self, *cards: ft.Control):
+        """Registers telemetry card instances to track for errors upon fetch completion."""
+        self._registered_cards.extend(cards)
+
+    def _safe_run_on_ui(self, callback: Callable):
+        """Dispatches UI updates safely on the event loop."""
+        try:
+            loop = getattr(self.page_ref, "loop", None)
+            if loop and callable(getattr(loop, "is_running", None)) and loop.is_running() and not isinstance(loop, ft.Page):
+                loop.call_soon_threadsafe(callback)
+            else:
+                callback()
+        except Exception:
+            callback()
+
+    def _notify_status(self, status: str):
+        """Notifies status change to parent dashboard."""
+        self.status = status
+        if self.on_status_change:
+            try:
+                self.on_status_change(status)
+            except Exception:
+                pass
+
+    def _check_completion_status(self, cards: Optional[List[ft.Control]] = None) -> str:
+        """Evaluates overall error status across registered or specified telemetry cards."""
+        target_cards = cards or self._registered_cards
+        has_error = any(getattr(c, "error_message", None) is not None for c in target_cards)
+        return SectionStatus.ERROR if has_error else SectionStatus.SUCCESS
+
+    def _reload_card(self, worker_func: Callable):
+        """Asynchronously executes single card reload in a daemon thread."""
+        self._notify_status(SectionStatus.LOADING)
+
+        def _wrapper():
+            try:
+                worker_func(is_reload=True)
+            finally:
+                def _done():
+                    self._notify_status(self._check_completion_status())
+                self._safe_run_on_ui(_done)
+
+        threading.Thread(target=_wrapper, daemon=True).start()

--- a/flet_ui/views/sections/ecosystem_integrations_view.py
+++ b/flet_ui/views/sections/ecosystem_integrations_view.py
@@ -25,6 +25,7 @@ from core.graph.directory.service_principals import ServicePrincipalsService
 from core.graph.exchange.connectors import fetch_exchange_connectors_data
 from core.graph.exchange.integrated_apps import run_exchange_apps_pipeline
 from telemetry.power_automate import run_power_automate_pipeline
+from flet_ui.views.sections.base_section_view import BaseSectionView
 from flet_ui.components.telemetry_card import TelemetryCard
 from flet_ui.styles import (
     COLOR_PRIMARY,
@@ -36,7 +37,7 @@ from flet_ui.styles import (
 logger = logging.getLogger("M365TelemetryAsyncLogger.EcosystemIntegrationsView")
 
 
-class EcosystemIntegrationsAutomationView(ft.Container):
+class EcosystemIntegrationsAutomationView(BaseSectionView):
     """View rendering all Ecosystem, Integrations & Automation telemetry cards with max 2 concurrency."""
 
     def __init__(
@@ -45,16 +46,15 @@ class EcosystemIntegrationsAutomationView(ft.Container):
         tenant: str = "",
         client: str = "",
         secret: str = "",
+        on_status_change: Optional[Callable[[str], None]] = None,
     ):
-        super().__init__()
-        self.page_ref = page
-        self.tenant = tenant
-        self.client_id = client
-        self.secret = secret
-
-        self.expand = True
-        self.is_fetched = False
-        self.is_fetching = False
+        super().__init__(
+            page=page,
+            tenant=tenant,
+            client=client,
+            secret=secret,
+            on_status_change=on_status_change,
+        )
 
         # Card container with vertical scrolling
         self.cards_column = ft.Column(
@@ -109,6 +109,14 @@ class EcosystemIntegrationsAutomationView(ft.Container):
             page_size=5,
             column_weights=[2, 3, 2, 3, 3],
             on_reload=lambda: self._reload_card(self._fetch_connectors_worker),
+        )
+
+        # Register cards with base class for error status tracking
+        self.register_cards(
+            self.power_automate_card,
+            self.integrated_apps_card,
+            self.service_principals_card,
+            self.connectors_card,
         )
 
         # Initial Placeholder State
@@ -175,22 +183,6 @@ class EcosystemIntegrationsAutomationView(ft.Container):
             ],
         )
 
-    def _safe_run_on_ui(self, callback: Callable):
-        """Dispatches UI updates safely on the event loop."""
-        try:
-            loop = getattr(self.page_ref, "loop", None)
-            if loop and callable(getattr(loop, "is_running", None)) and loop.is_running() and not isinstance(loop, ft.Page):
-                loop.call_soon_threadsafe(callback)
-            else:
-                callback()
-        except Exception:
-            callback()
-
-    def _reload_card(self, worker_func: Callable):
-        """Asynchronously executes single card reload in a daemon thread."""
-        import threading
-        threading.Thread(target=lambda: worker_func(is_reload=True), daemon=True).start()
-
     def fetch_all_data(self):
         """Initiates concurrent data fetch with maximum 2 parallel worker threads."""
         if self.is_fetching:
@@ -198,6 +190,7 @@ class EcosystemIntegrationsAutomationView(ft.Container):
 
         self.is_fetching = True
         self.is_fetched = True
+        self._notify_status("loading")
 
         self.cards_column.controls.clear()
 
@@ -294,6 +287,7 @@ class EcosystemIntegrationsAutomationView(ft.Container):
                     self.update()
                 except Exception:
                     pass
+                self._notify_status(self._check_completion_status())
 
             self._safe_run_on_ui(_on_all_completed)
 

--- a/flet_ui/views/sections/identity_licensing_view.py
+++ b/flet_ui/views/sections/identity_licensing_view.py
@@ -25,6 +25,7 @@ from core.graph.directory.domains import DomainsService
 from core.graph.directory.organization import OrganizationService
 from core.graph.directory.subscribed_skus import SubscribedSKUsService
 from core.graph.directory.users_groups import UsersGroupsService
+from flet_ui.views.sections.base_section_view import BaseSectionView
 from flet_ui.components.telemetry_card import TelemetryCard
 from flet_ui.styles import (
     COLOR_BORDER,
@@ -37,7 +38,7 @@ from flet_ui.styles import (
 logger = logging.getLogger("M365TelemetryAsyncLogger.IdentityLicensingView")
 
 
-class IdentityLicensingView(ft.Container):
+class IdentityLicensingView(BaseSectionView):
     """View rendering all Identity & Licensing telemetry cards with full-width layout and max 2 concurrency."""
 
     def __init__(
@@ -46,16 +47,15 @@ class IdentityLicensingView(ft.Container):
         tenant: str = "",
         client: str = "",
         secret: str = "",
+        on_status_change: Optional[Callable[[str], None]] = None,
     ):
-        super().__init__()
-        self.page_ref = page
-        self.tenant = tenant
-        self.client_id = client
-        self.secret = secret
-
-        self.expand = True
-        self.is_fetched = False
-        self.is_fetching = False
+        super().__init__(
+            page=page,
+            tenant=tenant,
+            client=client,
+            secret=secret,
+            on_status_change=on_status_change,
+        )
 
         # Card instances configured with full-width column weights
         self.cards_column = ft.Column(
@@ -103,6 +103,14 @@ class IdentityLicensingView(ft.Container):
             paginate=False,
             column_weights=[3, 1],
             on_reload=lambda: self._reload_card(self._fetch_users_groups_worker),
+        )
+
+        # Register cards with base class for error status tracking
+        self.register_cards(
+            self.org_card,
+            self.sku_card,
+            self.domains_card,
+            self.users_groups_card,
         )
 
         # Placeholder / Initial state
@@ -169,22 +177,6 @@ class IdentityLicensingView(ft.Container):
             ],
         )
 
-    def _safe_run_on_ui(self, callback: Callable):
-        """Dispatches UI updates safely on the event loop."""
-        try:
-            loop = getattr(self.page_ref, "loop", None)
-            if loop and callable(getattr(loop, "is_running", None)) and loop.is_running() and not isinstance(loop, ft.Page):
-                loop.call_soon_threadsafe(callback)
-            else:
-                callback()
-        except Exception:
-            callback()
-
-    def _reload_card(self, worker_func: Callable):
-        """Asynchronously executes single card reload in a daemon thread."""
-        import threading
-        threading.Thread(target=lambda: worker_func(is_reload=True), daemon=True).start()
-
     def fetch_all_data(self):
         """Initiates concurrent data fetch with maximum 2 parallel worker threads."""
         if self.is_fetching:
@@ -192,6 +184,7 @@ class IdentityLicensingView(ft.Container):
 
         self.is_fetching = True
         self.is_fetched = True
+        self._notify_status("loading")
 
         # Switch to cards layout with active fetching progress banner
         self.cards_column.controls.clear()
@@ -287,6 +280,7 @@ class IdentityLicensingView(ft.Container):
                     self.update()
                 except Exception:
                     pass
+                self._notify_status(self._check_completion_status())
 
             self._safe_run_on_ui(_on_all_completed)
 

--- a/flet_ui/views/sections/security_compliance_view.py
+++ b/flet_ui/views/sections/security_compliance_view.py
@@ -32,6 +32,7 @@ from core.graph.intune.device_compliance import run_device_compliance_pipeline
 from core.graph.intune.byod_configs import run_byod_configs_pipeline
 from core.graph.intune.managed_devices import run_managed_devices_pipeline
 from core.graph.intune.mobile_apps import run_mobile_apps_pipeline
+from flet_ui.views.sections.base_section_view import BaseSectionView
 from flet_ui.components.telemetry_card import TelemetryCard
 from flet_ui.styles import (
     COLOR_PRIMARY,
@@ -42,7 +43,7 @@ from flet_ui.styles import (
 logger = logging.getLogger("M365TelemetryAsyncLogger.SecurityComplianceView")
 
 
-class SecurityComplianceGovernanceView(ft.Container):
+class SecurityComplianceGovernanceView(BaseSectionView):
     """View rendering all Security, Compliance & Governance telemetry cards with max 2 concurrency."""
 
     def __init__(
@@ -51,16 +52,15 @@ class SecurityComplianceGovernanceView(ft.Container):
         tenant: str = "",
         client: str = "",
         secret: str = "",
+        on_status_change: Optional[Callable[[str], None]] = None,
     ):
-        super().__init__()
-        self.page_ref = page
-        self.tenant = tenant
-        self.client_id = client
-        self.secret = secret
-
-        self.expand = True
-        self.is_fetched = False
-        self.is_fetching = False
+        super().__init__(
+            page=page,
+            tenant=tenant,
+            client=client,
+            secret=secret,
+            on_status_change=on_status_change,
+        )
 
         # Card container with vertical scrolling and 18px right padding for scrollbar clearance
         self.cards_column = ft.Column(
@@ -211,6 +211,22 @@ class SecurityComplianceGovernanceView(ft.Container):
             on_reload=lambda: self._reload_card(self._fetch_cloud_pc_worker),
         )
 
+        # Register cards with base class for error status tracking
+        self.register_cards(
+            self.retention_card,
+            self.dlp_card,
+            self.sensitivity_card,
+            self.sit_card,
+            self.auth_policies_card,
+            self.ca_card,
+            self.mail_security_card,
+            self.device_compliance_card,
+            self.device_configs_card,
+            self.managed_devices_card,
+            self.mobile_apps_card,
+            self.cloud_pc_card,
+        )
+
         # Initial Placeholder State
         self.placeholder = self._build_placeholder()
 
@@ -275,22 +291,6 @@ class SecurityComplianceGovernanceView(ft.Container):
             ],
         )
 
-    def _safe_run_on_ui(self, callback: Callable):
-        """Dispatches UI updates safely on the event loop."""
-        try:
-            loop = getattr(self.page_ref, "loop", None)
-            if loop and callable(getattr(loop, "is_running", None)) and loop.is_running() and not isinstance(loop, ft.Page):
-                loop.call_soon_threadsafe(callback)
-            else:
-                callback()
-        except Exception:
-            callback()
-
-    def _reload_card(self, worker_func: Callable):
-        """Asynchronously executes single card reload in a daemon thread."""
-        import threading
-        threading.Thread(target=lambda: worker_func(is_reload=True), daemon=True).start()
-
     def fetch_all_data(self):
         """Initiates concurrent data fetch with maximum 2 parallel worker threads."""
         if self.is_fetching:
@@ -298,6 +298,7 @@ class SecurityComplianceGovernanceView(ft.Container):
 
         self.is_fetching = True
         self.is_fetched = True
+        self._notify_status("loading")
 
         all_cards = [
             self.retention_card,
@@ -377,6 +378,7 @@ class SecurityComplianceGovernanceView(ft.Container):
                             self.progress_banner.visible = False
                             self.is_fetching = False
                             self.cards_column.controls = visible_cards
+                            self._notify_status(self._check_completion_status())
                         else:
                             self.cards_column.controls = [self.progress_banner] + visible_cards
 

--- a/flet_ui/views/usage_adoption_dashboard_view.py
+++ b/flet_ui/views/usage_adoption_dashboard_view.py
@@ -22,6 +22,10 @@ import logging
 import threading
 from typing import Callable, Dict, List, Optional
 import flet as ft
+from flet_ui.components import (
+    SectionStatus,
+    create_section_status_indicator,
+)
 from flet_ui.styles import (
     COLOR_APP_BG,
     COLOR_BORDER,
@@ -96,6 +100,12 @@ class UsageAdoptionDashboardView(ft.Container):
 
         self.selected_index = 0
         self._stop_metrics = False
+        self.section_statuses: Dict[int, str] = {
+            0: SectionStatus.IDLE,
+            1: SectionStatus.IDLE,
+            2: SectionStatus.IDLE,
+            3: SectionStatus.IDLE,
+        }
 
         # System performance metric value controls
         self.ram_text = ft.Text("Loading...", size=12, weight=ft.FontWeight.W_600, color=COLOR_TEXT_PRIMARY)
@@ -108,24 +118,28 @@ class UsageAdoptionDashboardView(ft.Container):
             tenant=self.tenant,
             client=self.client,
             secret=self.secret,
+            on_status_change=lambda status: self._on_section_status_changed(0, status),
         )
         self.usage_view = AppUsageAdoptionView(
             page=self.page_ref,
             tenant=self.tenant,
             client=self.client,
             secret=self.secret,
+            on_status_change=lambda status: self._on_section_status_changed(1, status),
         )
         self.security_view = SecurityComplianceGovernanceView(
             page=self.page_ref,
             tenant=self.tenant,
             client=self.client,
             secret=self.secret,
+            on_status_change=lambda status: self._on_section_status_changed(2, status),
         )
         self.ecosystem_view = EcosystemIntegrationsAutomationView(
             page=self.page_ref,
             tenant=self.tenant,
             client=self.client,
             secret=self.secret,
+            on_status_change=lambda status: self._on_section_status_changed(3, status),
         )
 
         # Build UI Components
@@ -304,14 +318,52 @@ class UsageAdoptionDashboardView(ft.Container):
             content=sidebar_content,
         )
 
+    def _on_section_status_changed(self, index: int, status: str):
+        """Callback invoked when a section's fetch status changes."""
+        self.section_statuses[index] = status
+
+        def _update_nav():
+            self.nav_items_column.controls = [
+                self._create_nav_item(i, sec) for i, sec in enumerate(self.SECTIONS)
+            ]
+            try:
+                self.nav_items_column.update()
+            except Exception:
+                try:
+                    self.sidebar.update()
+                except Exception:
+                    try:
+                        self.update()
+                    except Exception:
+                        pass
+
+        self._safe_run_on_ui(_update_nav)
+
     def _create_nav_item(self, index: int, section: Dict[str, any]) -> ft.Container:
-        """Creates an individual navigation item with active / hover highlights."""
+        """Creates an individual navigation item with active / hover highlights and status icon."""
         is_selected = index == self.selected_index
+        status = self.section_statuses.get(index, SectionStatus.IDLE)
 
         bgcolor = COLOR_HERO_BG if is_selected else "transparent"
         text_color = COLOR_PRIMARY if is_selected else COLOR_TEXT_PRIMARY
         icon_color = COLOR_PRIMARY if is_selected else COLOR_TEXT_SECONDARY
         font_weight = ft.FontWeight.BOLD if is_selected else ft.FontWeight.W_500
+
+        # Status indicator control on the right end
+        status_control = create_section_status_indicator(status, is_selected=is_selected)
+
+        row_controls = [
+            ft.Icon(section["icon"], size=18, color=icon_color),
+            ft.Text(
+                section["title"],
+                size=13,
+                weight=font_weight,
+                color=text_color,
+                expand=True,
+            ),
+        ]
+        if status_control is not None:
+            row_controls.append(status_control)
 
         return ft.Container(
             border_radius=10,
@@ -320,18 +372,9 @@ class UsageAdoptionDashboardView(ft.Container):
             ink=True,
             on_click=lambda _: self._select_section(index),
             content=ft.Row(
-                spacing=12,
+                spacing=10,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
-                controls=[
-                    ft.Icon(section["icon"], size=18, color=icon_color),
-                    ft.Text(
-                        section["title"],
-                        size=13,
-                        weight=font_weight,
-                        color=text_color,
-                        expand=True,
-                    ),
-                ],
+                controls=row_controls,
             ),
         )
 
@@ -435,17 +478,14 @@ class UsageAdoptionDashboardView(ft.Container):
 
     def _handle_fetch_data(self):
         """Triggers data fetch for the active section placeholder."""
-        sec_name = self.SECTIONS[self.selected_index]["title"]
-        snack = ft.SnackBar(
-            content=ft.Text(f"Fetching telemetry data for {sec_name}..."),
-            open=True,
-        )
-        if hasattr(self.page_ref, "overlay"):
-            self.page_ref.overlay.append(snack)
-        try:
-            self.page_ref.update()
-        except Exception:
-            pass
+        if self.selected_index == 0:
+            self.identity_view.fetch_all_data()
+        elif self.selected_index == 1:
+            self.usage_view.fetch_all_data()
+        elif self.selected_index == 2:
+            self.security_view.fetch_all_data()
+        elif self.selected_index == 3:
+            self.ecosystem_view.fetch_all_data()
 
     def stop_metrics(self):
         """Stops the background real-time system metrics monitoring thread."""


### PR DESCRIPTION
## Summary

Implements section fetch status tracking in the left navigation panel of the Usage & Adoption telemetry module with modular architecture:

- **Section Status Indicators**:
  - **Idle**: No icon when fetch has not been triggered
  - **Loading**: Circular progress indicator (`ft.ProgressRing`) when section telemetry is being fetched
  - **Success**: Green tick (`ft.Icons.CHECK_ROUNDED`, `#16A34A`) when fetch completes without errors
  - **Error**: Red tick (`ft.Icons.CHECK_ROUNDED`, `#DC2626`) when fetch completes with one or more card errors
- **Modular Component Design**:
  - `SectionStatus` Enum and `SectionStatusIndicator` / `create_section_status_indicator` in `flet_ui/components/section_status_indicator.py`
  - `BaseSectionView` in `flet_ui/views/sections/base_section_view.py` providing shared status state, card registration, error evaluation, and thread-safe UI execution
  - Refactored all 4 section views (`IdentityLicensingView`, `AppUsageAdoptionView`, `SecurityComplianceGovernanceView`, `EcosystemIntegrationsAutomationView`) to inherit from `BaseSectionView`
  - Integrated reactive status updates in `UsageAdoptionDashboardView`
