### PR TITLE
fix(ui): Add 'Would you still like to continue?' to performance warning dialogs

### DIFF
--- a/ui/exchange_online_ui.py
+++ b/ui/exchange_online_ui.py
@@ -1332,7 +1332,8 @@ class MigrationEstimatorTool(ctk.CTk):
         warning_msg = (
             "Enabling 'Scan for Encrypted Emails' will cause performance degradation "
             "as it requires fetching content headers for emails to detect encryption. "
-            "It is highly recommended to only enable this if you need to identify RMS/MIP protected emails."
+            "It is highly recommended to only enable this if you need to identify RMS/MIP protected emails.\n\n"
+            "Would you still like to continue?"
         )
         should_continue = messagebox.askyesno(
             title="Performance Warning",

--- a/ui/files_ui.py
+++ b/ui/files_ui.py
@@ -1638,7 +1638,8 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         warning_msg = (
             "Enabling 'Include Historical File Versions in Corpus Size' will cause severe performance degradation "
             "as it requires fetching versions for every single file. "
-            "It is highly recommended to only enable this for a very small corpus (e.g., one SharePoint site or OneDrive site)."
+            "It is highly recommended to only enable this for a very small corpus (e.g., one SharePoint site or OneDrive site).\n\n"
+            "Would you still like to continue?"
         )
         should_continue = messagebox.askyesno(
             title="Performance Warning",
@@ -1653,7 +1654,8 @@ class FileMigrationEstimatorTool(MigrationEstimatorTool):
         warning_msg = (
             "Enabling 'Scan for Encrypted Files (RMS/MIP)' will cause performance degradation "
             "as it requires fetching content headers for every single file to detect encryption. "
-            "It is highly recommended to only enable this if you need to identify RMS/MIP protected files."
+            "It is highly recommended to only enable this if you need to identify RMS/MIP protected files.\n\n"
+            "Would you still like to continue?"
         )
         should_continue = messagebox.askyesno(
             title="Performance Warning",


### PR DESCRIPTION
When using the Files scanning tool, enabling either 'Include Historical File Versions in Corpus Size' or 'Scan for Encrypted Files (RMS/MIP)' brings up a warning dialog with Yes / No buttons. However, the message was previously just a statement without a clear question at the end, which felt a bit awkward next to the Yes/No buttons.

This PR adds a quick sentence at the end of the warning: *"Would you still like to continue?"* so the dialog flows naturally and makes it clear what Yes and No actually do.

 Also added the same line to the Exchange Online encrypted email warning for consistency.