### PR TITLE
fix: room mailbox naming in calendar metadata and VC devices footnote

### DIFF
--- a/core/powershell/scripts/exchange_calendar_metadata.ps1
+++ b/core/powershell/scripts/exchange_calendar_metadata.ps1
@@ -32,7 +32,7 @@ try {
     try {
         $rooms = @(Get-EXOMailbox -RecipientTypeDetails RoomMailbox -ResultSize Unlimited)
         $roomsCount = $rooms.Count
-        $roomsNaming = if ($rooms) { (($rooms | Select-Object -First 5 -ExpandProperty Name) -join ", ") } else { $null }
+        $roomsNaming = if ($rooms) { (($rooms | Select-Object -First 5 | ForEach-Object { if ($_.DisplayName) { $_.DisplayName } else { $_.Name } }) -join ", ") } else { $null }
     } catch {
         $roomsError = $_.Exception.Message
     }

--- a/flet_ui/views/sections/security_compliance_view.py
+++ b/flet_ui/views/sections/security_compliance_view.py
@@ -273,6 +273,7 @@ class SecurityComplianceGovernanceView(BaseSectionView):
             link_text="Open Intune Admin Center ↗",
             link_url="https://intune.microsoft.com/#view/Microsoft_Intune_DeviceSettings/DevicesMenu/~/allDevices",
             subtitle="Dedicated meeting room hardware and resource devices filtered from directory",
+            footnote="* Devices associated with room mailboxes or matching video conferencing hardware indicators are listed here. This serves as an estimated projection based on directory signals and is not a comprehensive, exact list of physical VC devices.",
             paginate=True,
             page_size=5,
             column_weights=[2, 2, 2, 1, 1, 1, 1],


### PR DESCRIPTION
### Summary of Changes

1. **Exchange Calendar Metadata Script (`core/powershell/scripts/exchange_calendar_metadata.ps1`)**:
   - Updated `$roomsNaming` extraction to use `DisplayName` (falling back to `Name`) so human-readable room mailbox names (e.g., "Test Room 01") populate the *Resource Naming Convention* metric in Calendar Settings, while keeping `$roomsList` with `PrimarySmtpAddress` for device matching.

2. **Security & Compliance View (`flet_ui/views/sections/security_compliance_view.py`)**:
   - Added explanatory footnote to the **Video Conferencing (VC) Devices** card explaining that the table lists devices associated with room mailboxes or matching video conferencing hardware indicators as an estimated projection based on directory signals.