### PR TITLE
feat(security): add Mailboxes on Legal Hold table and pipeline

### DIFF
--- a/core/graph/security/legal_holds.py
+++ b/core/graph/security/legal_holds.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mailboxes on Legal Hold PowerShell scanner data pipeline."""
+
+import logging
+from core.graph.client import GraphClient
+from core.graph.directory.organization import OrganizationService
+from core.powershell.client import PowerShellClient
+from core.powershell.mailbox import MailboxStatsService
+
+logger = logging.getLogger(__name__)
+
+
+def run_legal_holds_pipeline(
+    client_id: str,
+    client_secret: str,
+    tenant_id: str,
+) -> dict:
+    """Fetch mailboxes on legal hold via Exchange Online PowerShell."""
+    tenant_domain = tenant_id
+    client = GraphClient(
+        tenant_id=tenant_id,
+        client_ids=client_id,
+        client_secrets=client_secret,
+        concurrency=1,
+    )
+    try:
+        client.authenticate()
+        org_svc = OrganizationService(client)
+        tenant_domain = org_svc.get_tenant_primary_domain()
+        logger.info(f"Retrieved primary tenant domain for Legal Holds: {tenant_domain}")
+    except Exception as e:
+        logger.warning(f"Could not retrieve tenant domain for Legal Holds. Falling back to Tenant ID: {e}")
+    finally:
+        client.close()
+
+    ps_client = PowerShellClient(
+        tenant_id=tenant_domain,
+        client_id=client_id,
+        client_secret=client_secret,
+        cert_tenant_id=tenant_id,
+    )
+    mbx_service = MailboxStatsService(ps_client)
+    return mbx_service.fetch_legal_holds()

--- a/core/powershell/mailbox.py
+++ b/core/powershell/mailbox.py
@@ -61,6 +61,14 @@ class MailboxStatsService:
         try:
             return json.loads(raw_output)
         except json.JSONDecodeError:
+            # Extract JSON block between first '{' and last '}'
+            start_idx = raw_output.find("{")
+            end_idx = raw_output.rfind("}")
+            if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+                try:
+                    return json.loads(raw_output[start_idx : end_idx + 1])
+                except Exception:
+                    pass
             lines = raw_output.strip().split('\n')
             json_str = ""
             for line in lines:

--- a/core/powershell/scripts/get_legal_holds.ps1
+++ b/core/powershell/scripts/get_legal_holds.ps1
@@ -22,8 +22,28 @@ try {
     Import-Module ExchangeOnlineManagement -ErrorAction Stop
     Connect-ExchangeOnline -CertificateFilePath $CertificatePath -CertificatePassword $secPassword -AppId $AppId -Organization $Organization -ShowBanner:$false -WarningAction SilentlyContinue
 
-    # Get mailboxes on hold
-    $mailboxes = Get-Mailbox -ResultSize Unlimited | Where-Object {$_.InPlaceHolds -ne $null} | Select-Object DisplayName, InPlaceHolds
+    # Query all mailboxes on hold (both LitigationHoldEnabled and InPlaceHolds)
+    $mailboxes = Get-Mailbox -ResultSize Unlimited | Where-Object {
+        $_.LitigationHoldEnabled -eq $true -or ($_.InPlaceHolds -ne $null -and $_.InPlaceHolds.Count -gt 0)
+    } | ForEach-Object {
+        $holdsList = @()
+        if ($_.LitigationHoldEnabled) {
+            $holdsList += "Litigation Hold"
+        }
+        if ($_.InPlaceHolds) {
+            foreach ($h in $_.InPlaceHolds) {
+                if ($h -and "$h".Trim() -and "$h".Trim() -ne "-") {
+                    $holdsList += "$h".Trim()
+                }
+            }
+        }
+        [PSCustomObject]@{
+            DisplayName           = $_.DisplayName
+            UserPrincipalName     = if ($_.UserPrincipalName) { $_.UserPrincipalName } else { $_.PrimarySmtpAddress }
+            InPlaceHolds          = $holdsList
+            LitigationHoldEnabled = [bool]$_.LitigationHoldEnabled
+        }
+    }
     
     $result = @{
         "value" = @($mailboxes)

--- a/flet_ui/views/sections/security_compliance_view.py
+++ b/flet_ui/views/sections/security_compliance_view.py
@@ -27,6 +27,7 @@ from core.graph.security.retention_policies import run_retention_policies_pipeli
 from core.graph.security.dlp_policies import run_dlp_policies_pipeline
 from core.graph.security.sensitivity_labels import run_sensitivity_labels_pipeline
 from core.graph.security.sensitive_info_types import run_sensitive_info_types_pipeline
+from core.graph.security.legal_holds import run_legal_holds_pipeline
 from core.graph.network_security.conditional_access import run_conditional_access_pipeline
 from core.graph.network_security.filtering import run_filtering_pipeline
 from core.graph.network_security.firewall import run_firewall_pipeline
@@ -162,7 +163,19 @@ class SecurityComplianceGovernanceView(BaseSectionView):
             on_reload=lambda: self._reload_card(self._fetch_ediscovery_worker),
         )
 
-        # 8. Conditional Access Policies (Paginated listing - 5 columns)
+        # 8. Mailboxes on Legal Hold (Paginated listing - 3 columns)
+        self.legal_holds_card = TelemetryCard(
+            title="Mailboxes on Legal Hold",
+            link_text="Open Exchange Admin Center ↗",
+            link_url="https://admin.exchange.microsoft.com/#/mailboxes",
+            subtitle="Exchange Online user and shared mailboxes placed on Litigation Holds, eDiscovery holds, or retention policies",
+            paginate=True,
+            page_size=5,
+            column_weights=[1, 1, 1],
+            on_reload=lambda: self._reload_card(self._fetch_legal_holds_worker),
+        )
+
+        # 9. Conditional Access Policies (Paginated listing - 5 columns)
         self.ca_card = TelemetryCard(
             title="Conditional Access Policies",
             link_text="Open Azure Portal ↗",
@@ -350,6 +363,7 @@ class SecurityComplianceGovernanceView(BaseSectionView):
             self.custom_sit_card,
             self.edm_schemas_card,
             self.ediscovery_card,
+            self.legal_holds_card,
             self.ca_card,
             self.filtering_card,
             self.firewall_card,
@@ -443,7 +457,7 @@ class SecurityComplianceGovernanceView(BaseSectionView):
 
         self.cards_column.controls.clear()
 
-        total_tasks = 13
+        total_tasks = 14
 
         self.progress_bar = ft.ProgressBar(
             value=0.0,
@@ -483,6 +497,7 @@ class SecurityComplianceGovernanceView(BaseSectionView):
         self.custom_sit_card.set_loading("Fetching custom SITs...")
         self.edm_schemas_card.set_loading("Fetching EDM schemas...")
         self.ediscovery_card.set_loading("Fetching eDiscovery cases...")
+        self.legal_holds_card.set_loading("Fetching legal holds...")
         self.ca_card.set_loading("Fetching conditional access...")
         self.filtering_card.set_loading("Fetching filtering policies...")
         self.firewall_card.set_loading("Fetching firewall configurations...")
@@ -536,6 +551,7 @@ class SecurityComplianceGovernanceView(BaseSectionView):
             ("DLPPolicies", _track_task_wrapper(self._fetch_dlp_worker)),
             ("SITsAndEDMs", _track_task_wrapper(self._fetch_sits_worker)),
             ("EDiscoveryCases", _track_task_wrapper(self._fetch_ediscovery_worker)),
+            ("LegalHolds", _track_task_wrapper(self._fetch_legal_holds_worker)),
             ("ConditionalAccess", _track_task_wrapper(self._fetch_ca_worker)),
             ("NetworkSecurity", _track_task_wrapper(self._fetch_network_security_worker)),
             ("MailSecurity", _track_task_wrapper(self._fetch_mail_security_worker)),
@@ -996,8 +1012,84 @@ class SecurityComplianceGovernanceView(BaseSectionView):
 
             self._safe_run_on_ui(_on_error)
 
+    def _fetch_legal_holds_worker(self, is_reload: bool = False):
+        """8. Mailboxes on Legal Hold Worker via Exchange Online PowerShell (3 columns)."""
+        start_time = time.time()
+        logger.info("Executing Mailboxes on Legal Hold fetch task...")
+        headers = ["Mailbox Name", "User Principal Name (UPN)", "Applied Hold Policies"]
+        reports_dir, db_path = self._get_reports_dir_and_db()
+        csv_path = os.path.join(reports_dir, "legal_holds.csv")
+
+        try:
+            data = run_legal_holds_pipeline(
+                client_id=self.client_id,
+                client_secret=self.secret,
+                tenant_id=self.tenant,
+            )
+            lh_list = data.get("value", []) if isinstance(data, dict) else []
+            self.cached_data["legal_holds"] = lh_list
+
+            # Export to CSV & SQLite cache
+            os.makedirs(reports_dir, exist_ok=True)
+            with open(csv_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["DisplayName", "UserPrincipalName", "InPlaceHolds"])
+                for lh in lh_list:
+                    dname = lh.get("DisplayName") or lh.get("name") or "Unknown"
+                    upn = lh.get("UserPrincipalName") or lh.get("PrimarySmtpAddress") or "N/A"
+                    holds = lh.get("InPlaceHolds", [])
+                    if isinstance(holds, list):
+                        holds_str = ", ".join(str(h) for h in holds) if holds else "Litigation Hold"
+                    else:
+                        holds_str = str(holds) if holds else "Litigation Hold"
+                    writer.writerow([dname, upn, holds_str])
+
+            self._cache_to_sqlite_safe(csv_path, db_path, "legal_holds")
+
+            rows: List[List[Any]] = []
+            for lh in lh_list:
+                dname = lh.get("DisplayName") or lh.get("name") or "Unknown"
+                upn = lh.get("UserPrincipalName") or lh.get("PrimarySmtpAddress") or "N/A"
+                holds = lh.get("InPlaceHolds", [])
+                if isinstance(holds, list):
+                    holds_str = ", ".join(str(h) for h in holds) if holds else "Litigation Hold"
+                else:
+                    holds_str = str(holds) if holds else "Litigation Hold"
+                rows.append([dname, upn, holds_str])
+
+            elapsed = time.time() - start_time
+
+            def _on_success():
+                self.legal_holds_card.set_data(headers, rows, execution_time=elapsed)
+                if self.legal_holds_card not in self.cards_column.controls:
+                    self.cards_column.controls.append(self.legal_holds_card)
+                try:
+                    self.update()
+                except Exception:
+                    pass
+
+            self._safe_run_on_ui(_on_success)
+        except Exception as e:
+            logger.error(f"Error fetching Legal Holds: {e}", exc_info=True)
+            err_msg = str(e)
+            if "certificate" in err_msg.lower():
+                err_msg = "Certificate authentication missing or expired. Complete hybrid auth flow."
+            elif "pwsh" in err_msg.lower() or "powershell" in err_msg.lower():
+                err_msg = "PowerShell Core ('pwsh') is not installed or not available in PATH."
+
+            def _on_error():
+                self.legal_holds_card.set_error(f"Failed to fetch Mailboxes on Legal Hold: {err_msg}")
+                if self.legal_holds_card not in self.cards_column.controls:
+                    self.cards_column.controls.append(self.legal_holds_card)
+                try:
+                    self.update()
+                except Exception:
+                    pass
+
+            self._safe_run_on_ui(_on_error)
+
     def _fetch_ca_worker(self, is_reload: bool = False):
-        """8. Conditional Access Policies Worker (5 columns)."""
+        """9. Conditional Access Policies Worker (5 columns)."""
         start_time = time.time()
         logger.info("Executing Conditional Access Policies fetch task...")
         headers = ["Policy Name", "State", "Target Users", "Grant Controls", "Client Apps"]


### PR DESCRIPTION
### Summary of Changes

1. **New Pipeline (`core/graph/security/legal_holds.py`)**:
   - Implemented `run_legal_holds_pipeline` with automatic tenant primary domain resolution (`OrganizationService.get_tenant_primary_domain()`) for Exchange Online PowerShell authentication.

2. **PowerShell Query Fixes (`core/powershell/scripts/get_legal_holds.ps1`)**:
   - Updated mailbox query to capture both `LitigationHoldEnabled` and `InPlaceHolds`.
   - Included `UserPrincipalName` in output payload.
   - Removed incompatible `-Properties` argument from `Get-Mailbox`.

3. **Backend Service Improvements (`core/powershell/mailbox.py`)**:
   - Enhanced JSON parsing with delimiter boundary extraction to reliably isolate JSON blocks from PowerShell diagnostic output.

4. **Security View Card Integration (`flet_ui/views/sections/security_compliance_view.py`)**:
   - Added **Mailboxes on Legal Hold** table with 3 balanced columns (`Mailbox Name`, `User Principal Name (UPN)`, `Applied Hold Policies`) with `[1, 1, 1]` column weights.
   - Wired with async fetch, caching to SQLite/CSV, and independent card reload.