### PR TITLE
fix(ecosystem): handle Power Automate partial scan errors with UI warning notice

### DIFF
--- a/flet_ui/views/sections/ecosystem_integrations_view.py
+++ b/flet_ui/views/sections/ecosystem_integrations_view.py
@@ -394,9 +394,29 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
 
     # --- Telemetry Worker Pipelines ---
 
-    def _format_dataverse_error(self, err: str) -> str:
-        """Formats raw Dataverse error string into a short, concise user-facing explanation without full URLs or stack traces."""
+    def _format_power_automate_error(self, err: str) -> str:
+        """Formats raw Power Automate error string into a short, concise user-facing explanation without full URLs or stack traces."""
         err_lower = err.lower()
+
+        # 1. Cloud Flows Environment error (e.g. Cloud Flows (Production Env): 403 Forbidden)
+        if "cloud flows (" in err_lower:
+            env_name = ""
+            try:
+                env_name = err.split("Cloud Flows (")[1].split(")")[0]
+            except Exception:
+                env_name = ""
+            env_label = f" [{env_name}]" if env_name else ""
+            if "403" in err or "forbidden" in err_lower or "unauthorized" in err_lower:
+                return f"• Environment{env_label}: HTTP 403 Forbidden — App registration lacks Environment Admin permissions to scan Cloud Flows."
+            elif "404" in err or "not found" in err_lower:
+                return f"• Environment{env_label}: HTTP 404 Not Found — Environment flows endpoint unavailable."
+            elif "429" in err or "throttled" in err_lower:
+                return f"• Environment{env_label}: HTTP 429 Too Many Requests — Request rate limit exceeded."
+            else:
+                short_msg = err.split("for url:")[0].strip() if "for url:" in err else err[:120].strip()
+                return f"• Environment{env_label}: {short_msg}"
+
+        # 2. Dataverse Desktop Flows error (e.g. Dataverse Authentication (https://...): 403 Forbidden)
         instance = ""
         if "dataverse authentication (" in err_lower:
             try:
@@ -634,8 +654,21 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
             extra_controls: List[ft.Control] = []
 
             if errs:
-                formatted_errs = [self._format_dataverse_error(e) for e in errs]
+                formatted_errs = [self._format_power_automate_error(e) for e in errs]
                 err_text = "\n".join(formatted_errs)
+                
+                notice_title = (
+                    "Partial Scan Notice: Access Limitations Detected"
+                    if total_flows > 0
+                    else "Scan Notice: Environment Access Restricted"
+                )
+                notice_desc = (
+                    "Cloud Flows, environments, and connector telemetry were retrieved for accessible environments. "
+                    "However, one or more environments or Dataverse instances could not be scanned due to permissions:"
+                    if total_flows > 0
+                    else "Discovered environments could not be scanned because the application registration lacks the required administrator permissions:"
+                )
+
                 warning_box = ft.Container(
                     bgcolor="#FFFBEB",
                     border=ft.Border.all(1, "#FCD34D"),
@@ -651,14 +684,13 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
                                 expand=True,
                                 controls=[
                                     ft.Text(
-                                        "Partial Scan Notice: Desktop Flows Inaccessible",
+                                        notice_title,
                                         size=12,
                                         weight=ft.FontWeight.BOLD,
                                         color="#92400E",
                                     ),
                                     ft.Text(
-                                        "Cloud Flows, environments, and connector telemetry were retrieved successfully. "
-                                        "However, Desktop Flows (RPA) could not be retrieved from one or more Dataverse environments:",
+                                        notice_desc,
                                         size=11,
                                         color="#92400E",
                                     ),

--- a/flet_ui/views/sections/ecosystem_integrations_view.py
+++ b/flet_ui/views/sections/ecosystem_integrations_view.py
@@ -394,6 +394,32 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
 
     # --- Telemetry Worker Pipelines ---
 
+    def _format_dataverse_error(self, err: str) -> str:
+        """Formats raw Dataverse error string into a short, concise user-facing explanation without full URLs or stack traces."""
+        err_lower = err.lower()
+        instance = ""
+        if "dataverse authentication (" in err_lower:
+            try:
+                instance = err.split("Dataverse Authentication (")[1].split(")")[0]
+            except Exception:
+                instance = ""
+
+        inst_label = f" [{instance}]" if instance else ""
+
+        if "403" in err or "forbidden" in err_lower or "not a member" in err_lower:
+            return f"• Dataverse Instance{inst_label}: HTTP 403 Forbidden — App registration lacks Application User permissions in this environment (Desktop Flows skipped)."
+        elif "401" in err or "unauthorized" in err_lower:
+            return f"• Dataverse Instance{inst_label}: HTTP 401 Unauthorized — Authentication failed for Dataverse instance."
+        elif "404" in err or "not found" in err_lower:
+            return f"• Dataverse Instance{inst_label}: HTTP 404 Not Found — Dataverse workflows endpoint unavailable."
+        elif "429" in err or "throttled" in err_lower or "too many requests" in err_lower:
+            return f"• Dataverse Instance{inst_label}: HTTP 429 Too Many Requests — Request rate limit exceeded."
+        elif "timeout" in err_lower:
+            return f"• Dataverse Instance{inst_label}: Connection timed out while querying Desktop Flows."
+        else:
+            short_msg = err.split("for url:")[0].strip() if "for url:" in err else err[:120].strip()
+            return f"• Dataverse Instance{inst_label}: {short_msg}"
+
     def _generate_power_automate_chart(
         self,
         cloud_active: int,
@@ -521,7 +547,8 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
 
             errs = results.get("errors", [])
             if errs:
-                raise Exception("; ".join(errs))
+                for err in errs:
+                    logger.error(f"Power Automate partial scan error: {err}")
 
             columns = ["Metric", "Value"]
             total_envs = results.get("total_environments", 0)
@@ -604,12 +631,56 @@ class EcosystemIntegrationsAutomationView(BaseSectionView):
                 ],
             )
 
-            extra_controls: List[ft.Control] = [
+            extra_controls: List[ft.Control] = []
+
+            if errs:
+                formatted_errs = [self._format_dataverse_error(e) for e in errs]
+                err_text = "\n".join(formatted_errs)
+                warning_box = ft.Container(
+                    bgcolor="#FFFBEB",
+                    border=ft.Border.all(1, "#FCD34D"),
+                    border_radius=8,
+                    padding=ft.Padding(14, 12, 14, 12),
+                    content=ft.Row(
+                        spacing=10,
+                        vertical_alignment=ft.CrossAxisAlignment.START,
+                        controls=[
+                            ft.Icon(ft.Icons.WARNING_AMBER_ROUNDED, color="#D97706", size=20),
+                            ft.Column(
+                                spacing=3,
+                                expand=True,
+                                controls=[
+                                    ft.Text(
+                                        "Partial Scan Notice: Desktop Flows Inaccessible",
+                                        size=12,
+                                        weight=ft.FontWeight.BOLD,
+                                        color="#92400E",
+                                    ),
+                                    ft.Text(
+                                        "Cloud Flows, environments, and connector telemetry were retrieved successfully. "
+                                        "However, Desktop Flows (RPA) could not be retrieved from one or more Dataverse environments:",
+                                        size=11,
+                                        color="#92400E",
+                                    ),
+                                    ft.Text(
+                                        err_text,
+                                        size=11,
+                                        color="#B45309",
+                                        selectable=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+                extra_controls.append(warning_box)
+
+            extra_controls.append(
                 ft.Container(
                     padding=ft.Padding(0, 4, 0, 0),
                     content=footnotes,
                 )
-            ]
+            )
 
             if chart_base64:
                 chart_img = ft.Image(

--- a/telemetry/power_automate.py
+++ b/telemetry/power_automate.py
@@ -191,13 +191,16 @@ class PowerAutomateScanner:
             # 1. FETCH CLOUD FLOWS
             # ==========================================
             flows_url = f"https://api.flow.microsoft.com/providers/Microsoft.ProcessSimple/scopes/admin/environments/{env_name}/v2/flows?api-version=2016-11-01"
-            cloud_flows = self.fetch_all_pages(flows_url, flow_headers, context_name="Cloud Flows Admin API (V2)")
-            
-            counts["Cloud Flows"] += len(cloud_flows)
-            active_cloud_flows = [f for f in cloud_flows if f.get("properties", {}).get("state") == "Started"]
-            active_counts["Cloud Flows"] += len(active_cloud_flows)
-            
-            self.logger.info(f"    -> Cloud Flows: {len(cloud_flows)} total found, {len(active_cloud_flows)} are currently active.")
+            try:
+                cloud_flows = self.fetch_all_pages(flows_url, flow_headers, context_name="Cloud Flows Admin API (V2)")
+                counts["Cloud Flows"] += len(cloud_flows)
+                active_cloud_flows = [f for f in cloud_flows if f.get("properties", {}).get("state") == "Started"]
+                active_counts["Cloud Flows"] += len(active_cloud_flows)
+                self.logger.info(f"    -> Cloud Flows: {len(cloud_flows)} total found, {len(active_cloud_flows)} are currently active.")
+            except Exception as e:
+                self.logger.error(f"      [X] Failed to fetch Cloud Flows for environment {env_display}: {e}")
+                errors.append(f"Cloud Flows ({env_display}): {e}")
+                cloud_flows = []
             
             # Fetch details in parallel using ThreadPoolExecutor
             


### PR DESCRIPTION
### Summary of Changes

1. **Per-Environment Cloud Flow Error Handling (`telemetry/power_automate.py`)**:
   - Wrapped `fetch_all_pages(flows_url, ...)` in a `try...except` inside the environment loop. If an environment fails (e.g. 403 due to missing Environment Admin role), the error is logged and appended to `errors`, allowing the scanner to continue processing the remaining accessible environments without aborting.

2. **Non-Fatal Partial Error Handling (`flet_ui/views/sections/ecosystem_integrations_view.py`)**:
   - Replaced `raise Exception("; ".join(errs))` with background logging (`logger.error`), ensuring that partial failures in Dataverse or specific cloud environments do not crash the card or discard valid flow telemetry.

3. **Context-Aware Error Formatter (`_format_power_automate_error`)**:
   - Formats raw exception strings into concise, actionable bullet points for both Cloud Flow environment restrictions and Dataverse Desktop Flow authorization errors without dumping long URLs or stack traces.

4. **Adaptive UI Warning Banner**:
   - Renders an amber notice box that dynamically adapts its message based on whether partial flows were retrieved (`Partial Scan Notice: Access Limitations Detected`) or all discovered environments failed (`Scan Notice: Environment Access Restricted`).