### PR TITLE
chore: pin flet version to 0.86.5 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ aiosqlite
 Pillow
 urllib3
 certifi
+flet==0.86.5


### PR DESCRIPTION
This PR pins the flet dependency to version 0.86.5 to ensure stability.